### PR TITLE
feat(core): parallel branch yields with consensus-aware merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,9 @@ hensu-langchain4j-adapter     # LangChain4j integration (Claude, GPT, Gemini, De
 - `WorkflowStateRepository` - Tenant-scoped storage for execution state snapshots (defaults to in-memory; JDBC impl in server)
 - `ExecutionListener` - Lifecycle callbacks including `onCheckpoint(HensuState)` for inter-node persistence
 - `ProcessorPipeline` - Orchestrates pre/post node execution processor chains
+- `EngineVariables` - SSOT for engine-managed variable names (`score`, `approved`, `recommendation`)
+- `AgentLifecycleRunner` - Stateless agent call lifecycle (resolve → enrich → lookup → listener → execute → convert); shared by `StandardNodeExecutor` and `ParallelNodeExecutor`
+- `SynchronizedListenerDecorator` - Thread-safe `ExecutionListener` wrapper for parallel branch execution
 
 **Execution Lifecycle**: The `WorkflowExecutor` processes each node through a strict PRE-EXECUTE-POST pipeline.
 Pre-execution processors run in order: checkpoint → node start. Post-execution processors run in order: output
@@ -142,7 +145,7 @@ Workflow
 
 - `StandardNode` - Regular step with agent execution, typed state variable output (`writes`), and transitions
 - `LoopNode` - Iterative execution with break conditions
-- `ParallelNode` - Concurrent execution with consensus
+- `ParallelNode` - Concurrent execution with consensus; branches declare domain output via `yields()`
 - `ForkNode` - Spawn parallel execution paths
 - `JoinNode` - Await and merge forked paths
 - `GenericNode` - Custom execution logic via registered handlers
@@ -154,7 +157,7 @@ Workflow
 
 - `SuccessTransition` / `FailureTransition` - Based on execution result
 - `ScoreTransition` - Conditional on rubric score (e.g., score >= 80 → approve)
-- `ApprovalTransition` - Routes on the `approved` boolean engine variable (written via `writes("approved")`); falls through if absent or non-boolean
+- `ApprovalTransition` - Routes on the `approved` boolean engine variable (injected by `ApprovalVariableInjector`); falls through if absent or non-boolean
 - `AlwaysTransition` - Unconditional
 
 ### State Schema
@@ -374,6 +377,11 @@ CRUD operations, UPSERT semantics, FK constraints, tenant isolation, and seriali
 - `hensu-core/.../workflow/state/WorkflowStateSchema.java` - Typed state variable schema (optional per-workflow declaration)
 - `hensu-core/.../workflow/state/StateVariableDeclaration.java` - Single variable declaration (name, type, isInput)
 - `hensu-core/.../workflow/state/VarType.java` - Variable type enum (STRING, NUMBER, BOOLEAN, LIST_STRING)
+- `hensu-core/.../execution/EngineVariables.java` - SSOT for engine-managed variable names (score, approved, recommendation)
+- `hensu-core/.../execution/SynchronizedListenerDecorator.java` - Thread-safe listener wrapper for parallel branches
+- `hensu-core/.../execution/executor/AgentLifecycleRunner.java` - Shared agent call lifecycle (resolve → enrich → execute)
+- `hensu-core/.../execution/parallel/BranchExecutionConfig.java` - Per-branch config carried on ExecutionContext
+- `hensu-core/.../execution/enricher/YieldsVariableInjector.java` - Injects yield format instructions for branch prompts
 - `hensu-core/.../workflow/transition/ApprovalTransition.java` - Boolean approval routing via `approved` engine variable
 - `hensu-core/.../workflow/validation/WorkflowValidator.java` - Load-time validator for `writes` and prompt variable references
 

--- a/docs/developer-guide-core.md
+++ b/docs/developer-guide-core.md
@@ -11,6 +11,7 @@ This guide covers API usage, adapter development, extension points, and testing 
 - [Execution Pipeline](#execution-pipeline)
   - [Pre-Execution Pipeline](#pre-execution-pipeline)
   - [Post-Execution Pipeline](#post-execution-pipeline)
+  - [Parallel Branch Concurrency](#parallel-branch-concurrency)
   - [Agentic Output Validation](#agentic-output-validation)
 - [Creating Custom Adapters](#creating-custom-adapters)
 - [Generic Nodes](#generic-nodes)
@@ -193,6 +194,29 @@ step, enabling self-correcting loops.
 **`TransitionPostProcessor`** — The final step. Evaluates the current node's `TransitionRule` list in order. The first
 rule that returns a valid target node ID wins, and the state is updated to point to that next node. Throws
 `IllegalStateException` if no rule matches, preventing the workflow from silently getting stuck.
+
+### Parallel Branch Concurrency
+
+`ParallelNodeExecutor` runs each branch on a virtual thread with two concurrency guarantees:
+
+**1. ScopedValue isolation** – each branch receives an isolated context snapshot bound via
+`ScopedValue.where(BRANCH_CONTEXT, snapshot)`. Branch mutations never leak into sibling branches
+or the parent state. This is the same mechanism used for tenant isolation (`TenantContext`).
+
+> **Extension rule:** Never use `ThreadLocal` in branch-aware code. `ScopedValue` is the only
+> safe context propagation mechanism for virtual threads. See `10-java-standards.md` for details.
+
+**2. SynchronizedListenerDecorator** – the parent `ExecutionListener` is wrapped in a
+`SynchronizedListenerDecorator` before branch submission. Every callback is `synchronized` so that
+multi-line output (e.g., box-drawing in verbose CLI, SSE event frames) completes atomically without
+interleaving across concurrent branches.
+
+Custom `ExecutionListener` implementations do **not** need their own synchronization when used with
+parallel nodes – the decorator handles it. Only the parallel execution path pays the synchronization
+cost; sequential nodes use the raw listener.
+
+> **JEP 491 (Java 24+):** Virtual thread pinning on `synchronized` blocks was eliminated. Monitor
+> contention on I/O-bound listener callbacks is negligible for typical branch counts (3–10).
 
 ### Agentic Output Validation
 
@@ -711,27 +735,40 @@ Validation is a no-op when no schema is declared. Legacy workflows always pass t
 
 ## Engine Variable Injection
 
-Before each agent call, `StandardNodeExecutor` runs `EngineVariablePromptEnricher` to append
+Before each agent call, `AgentLifecycleRunner` runs `EngineVariablePromptEnricher` to append
 format requirements to the resolved prompt. The enricher is a dumb iterator over an ordered chain
 of `EngineVariableInjector`s — each one self-contained, deciding independently whether it applies.
 
+Engine variable names (`score`, `approved`, `recommendation`) are defined in the `EngineVariables`
+class — the single source of truth for all engine-managed variable keys.
+
 ### Injection Pipeline
+
+Each injector fires when **either** of two conditions is met:
+1. The node has a matching transition rule (e.g., `ScoreTransition` for `ScoreVariableInjector`)
+2. The execution context carries a `BranchExecutionConfig` where `needsSelfScoring()` returns true
+   (consensus branch with a non-JUDGE_DECIDES strategy)
 
 ```mermaid
 flowchart LR
-    r(["RubricPromptInjector"]) -->|"rubricId != null"| s(["ScoreVariableInjector"])
-    s -->|"has ScoreTransition"| a(["ApprovalVariableInjector"])
-    a -->|"has ApprovalTransition"| rec(["RecommendationVariable\nInjector"])
-    rec -->|"has Score/Approval\nTransition"| w(["WritesVariableInjector"])
+    r(["RubricPromptInjector\n· rubricId != null"]) --> s(["ScoreVariableInjector\n· ScoreTransition or\nconsensus branch"])
+    s --> a(["ApprovalVariableInjector\n· ApprovalTransition or\nconsensus branch"])
+    a --> rec(["RecommendationVariable\nInjector\n· Score/Approval or\nconsensus branch"])
+    rec --> w(["WritesVariableInjector\n· has writes()"])
+    w --> y(["YieldsVariableInjector\n· has yields()"])
 
     style r fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
     style s fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
     style a fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
     style rec fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
     style w fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
+    style y fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
 
     linkStyle default stroke:#0A84FF, stroke-width:1px
 ```
+
+Each injector runs unconditionally in order. The condition listed under each name is when that
+injector **appends** its instruction – otherwise it passes the prompt through unchanged.
 
 ### Description Hints in WritesVariableInjector
 
@@ -757,6 +794,7 @@ EngineVariablePromptEnricher enricher = new EngineVariablePromptEnricher(
         new ApprovalVariableInjector(),
         new RecommendationVariableInjector(),
         new WritesVariableInjector(),
+        new YieldsVariableInjector(),
         new MyCustomInjector()   // appended after built-ins
     ));
 ```
@@ -1268,7 +1306,11 @@ Environment variables matching `*_API_KEY`, `*_KEY`, `*_SECRET`, or `*_TOKEN` pa
 | `plan/Planner.java`                                     | Planner interface (`createPlan` / `revisePlan`)                                                  |
 | `plan/StaticPlanner.java`                               | Resolves predefined `plan { }` steps from `PlanningConfig`                                       |
 | `plan/LlmPlanner.java`                                  | LLM-based plan generation and revision (`DYNAMIC` mode)                                          |
+| `execution/EngineVariables.java`                        | SSOT for engine variable names (`score`, `approved`, `recommendation`)                           |
+| `execution/SynchronizedListenerDecorator.java`          | Thread-safe listener wrapper for parallel branch execution                                       |
+| `execution/executor/AgentLifecycleRunner.java`          | Composition-based agent call: prompt enrichment → agent execution → output extraction            |
 | `execution/executor/AgenticNodeExecutor.java`           | Drives preparation + execution `PlanPipeline`s for `StandardNode`                                |
+| `execution/parallel/BranchExecutionConfig.java`         | Typed branch metadata on `ExecutionContext` (consensus strategy, yields list)                    |
 | `template/SimpleTemplateResolver.java`                  | `{variable}` substitution                                                                        |
 | `review/ReviewHandler.java`                             | Human review interface                                                                           |
 | `execution/pipeline/ProcessorPipeline.java`             | Orchestrates pre/post processor chains                                                           |

--- a/docs/developer-guide-serialization.md
+++ b/docs/developer-guide-serialization.md
@@ -236,12 +236,35 @@ Java records have no inner `Builder` class — Jackson deserializes them via the
 
 ### Current registrations
 
+**Snapshot hierarchy** (embedded in `ExecutionStep`):
+
 | Class                              | Embedded in                      | Reason                                      |
 |------------------------------------|----------------------------------|---------------------------------------------|
 | `HensuSnapshot`                    | `ExecutionStep.Builder.snapshot` | Canonical constructor + component accessors |
 | `PlanSnapshot`                     | `HensuSnapshot.planSnapshot`     | Nested record inside `HensuSnapshot`        |
 | `PlanSnapshot.PlannedStepSnapshot` | `PlanSnapshot.steps()`           | Nested record inside `PlanSnapshot`         |
 | `PlanSnapshot.StepResultSnapshot`  | `PlanSnapshot.results()`         | Nested record inside `PlanSnapshot`         |
+
+**Parallel execution types** (manually deserialized in `NodeDeserializer`, but serialized via default Jackson `BeanSerializer` in `WorkflowSerializer.toJson()`):
+
+| Class                       | Embedded in / Context                           | Reason                                                      |
+|-----------------------------|-------------------------------------------------|-------------------------------------------------------------|
+| `Branch`                    | `ParallelNode` branch list                      | Record with `yields` (`List<String>`) component             |
+| `ConsensusConfig`           | `ParallelNode` consensus configuration          | Record with strategy enum + nullable threshold              |
+| `ConsensusStrategy`         | `ConsensusConfig.strategy()`                    | Enum – Jackson needs reflection to serialize enum constants |
+| `ConsensusResult`           | State context map (checkpoint serialization)    | Stored under `consensus_votes` key during execution         |
+| `ConsensusResult.Vote`      | `ConsensusResult.votes()` map values            | Inner record with vote type, score, weight                  |
+| `ConsensusResult.VoteType`  | `ConsensusResult.Vote.voteType()`               | Enum (APPROVE / REJECT)                                     |
+| `ScoreCondition`            | `ScoreTransition` condition list                | Nested record inside transition rules                       |
+| `DoubleRange`               | `ScoreCondition.range()`                        | Nested record inside `ScoreCondition`                       |
+
+> **Why not `treeToValue`?** These types are simple records with primitive/string/enum fields.
+> Manual `JsonNode` extraction in `NodeDeserializer` avoids reflection during deserialization.
+> Registration is needed only for the **serialization** path (`WorkflowSerializer.toJson()`),
+> where Jackson's default `BeanSerializer` reads component accessors reflectively.
+
+> **`Branch.yields`** is a `List<String>`. `NodeDeserializer` extracts it by iterating the JSON
+> array node manually — no `treeToValue` or `convertValue` needed for `List<String>`.
 
 Unlike the `treeToValue` pattern, these records do **not** need a custom deserializer or mixin. Registration alone is sufficient because Jackson's built-in record support handles the canonical constructor mapping.
 

--- a/docs/developer-guide-server.md
+++ b/docs/developer-guide-server.md
@@ -1268,15 +1268,19 @@ Registrations are split across four dedicated classes to keep each concern isola
 
 #### NativeImageConfig — Hensu domain model
 
-**Three patterns require registration here:**
+**Five patterns require registration here** (matching `NativeImageConfig` javadoc §1–§5):
 
 1. **`@JsonPOJOBuilder` mixin targets** — Jackson instantiates the builder via its private no-arg constructor, calls each setter, then calls `build()`. GraalVM cannot trace these calls through the generic mixin machinery.
 
 2. **`treeToValue` delegation** — When a custom deserializer calls `mapper.treeToValue(node, SomeClass.class)`, Jackson uses POJO reflection for `SomeClass`. Simple records (primitives, strings, enums only) should be **fixed** by switching to manual `JsonNode` extraction instead. Register only types where manual extraction is impractical (e.g., nested `Duration` fields).
 
-3. **Record types embedded in builder classes** — When a `record` is a field inside a mixin-registered builder type, Jackson reaches it via its canonical constructor and component accessors. GraalVM cannot trace those calls statically. Register the record and every nested record transitively. No mixin or custom deserializer is needed — registration alone is sufficient.
+3. **Manual deser, default Jackson ser** — Types deserialized manually in `NodeDeserializer` (direct `JsonNode` extraction) but serialized via Jackson's default `BeanSerializer` in `WorkflowSerializer.toJson()`. The deserialization path needs no reflection, but the serialization path reads record component accessors reflectively. Current types: `Branch`, `ConsensusConfig`, `ConsensusStrategy`, `ConsensusResult`, `ConsensusResult.Vote`, `ConsensusResult.VoteType`, `ScoreCondition`, `DoubleRange`.
 
-**When to add vs. fix:** if the class is a simple record with no `Duration`/nested-complex fields, fix the deserializer. If it contains `Duration` or deeply nested types, add it here. For records embedded in builder types, always register them. See [hensu-serialization Developer Guide](developer-guide-serialization.md#the-treetovalue-rule) for the full rule.
+4. **Simple immutable types with custom deser but default ser** — `WorkflowStateSchema` and `StateVariableDeclaration` use a custom deserializer (`WorkflowStateSchemaDeserializer`) that extracts fields manually. However, Jackson's default serializer reads `getVariables()` reflectively, so both classes must be registered.
+
+5. **Record types embedded in builder classes** — When a `record` is a field inside a mixin-registered builder type, Jackson reaches it via its canonical constructor and component accessors. GraalVM cannot trace those calls statically. Register the record and every nested record transitively. No mixin or custom deserializer is needed — registration alone is sufficient. Current types: `ReviewConfig`, `HensuSnapshot`, `PlanSnapshot` hierarchy.
+
+**When to add vs. fix:** if the class is a simple record with no `Duration`/nested-complex fields, fix the deserializer. If it contains `Duration` or deeply nested types, add it here. For records embedded in builder types, always register them. For types in pattern 3, registration is needed only because the serialization path uses default Jackson. See [hensu-serialization Developer Guide](developer-guide-serialization.md#the-treetovalue-rule) for the full rule.
 
 #### LangChain4j*NativeConfig — third-party provider DTOs
 

--- a/docs/dsl-reference.md
+++ b/docs/dsl-reference.md
@@ -192,14 +192,17 @@ parallel("review-committee") {
     branch("reviewer1") {
         agent = "reviewer"
         prompt = "Review the content: {previous-output}"
+        yields("feedback", "suggestions")
     }
     branch("reviewer2") {
         agent = "reviewer"
         prompt = "Review the content: {previous-output}"
+        yields("feedback", "suggestions")
     }
     branch("reviewer3") {
         agent = "reviewer"
         prompt = "Review the content: {previous-output}"
+        yields("feedback", "suggestions")
     }
 
     consensus {
@@ -214,12 +217,13 @@ parallel("review-committee") {
 
 #### Branch Properties
 
-| Property | Type    | Required | Description                                                                                                                                                           |
-|----------|---------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `agent`  | String  | Yes      | ID of the agent to execute                                                                                                                                            |
-| `prompt` | String? | No       | Prompt template or `.md` file reference                                                                                                                               |
-| `rubric` | String? | No       | ID of rubric for branch evaluation. When set, the rubric's pass/fail result determines the branch's consensus vote (APPROVE/REJECT), overriding text-based heuristics |
-| `weight` | Double  | No       | Vote weight for `WEIGHTED_VOTE` consensus strategy. Higher values give more influence to the branch score (default: 1.0)                                              |
+| Property   | Type          | Required | Description                                                                                                                                                                         |
+|------------|---------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `agent`    | String        | Yes      | ID of the agent to execute                                                                                                                                                          |
+| `prompt`   | String?       | No       | Prompt template or `.md` file reference                                                                                                                                             |
+| `rubric`   | String?       | No       | ID of rubric for branch evaluation. When set, the rubric's pass/fail result determines the branch's consensus vote (APPROVE/REJECT), overriding text-based heuristics               |
+| `weight`   | Double        | No       | Vote weight for `WEIGHTED_VOTE` consensus strategy. Higher values give more influence to the branch score (default: 1.0)                                                            |
+| `yields()` | vararg String | No       | State variable names this branch produces as structured domain output. The agent's JSON response must include these fields; the engine extracts and merges them into workflow state |
 
 #### Rubric-Based Consensus
 
@@ -228,7 +232,18 @@ When a branch declares a `rubric`, the engine evaluates the branch output agains
 - **Rubric passed** → branch votes **APPROVE** with the rubric score
 - **Rubric failed** → branch votes **REJECT** with the rubric score
 
-Branches without a rubric fall back to text-based heuristics (keyword detection, score pattern extraction). This allows mixing rubric-evaluated and heuristic-evaluated branches in the same parallel node.
+Branches without a rubric use engine-injected self-scoring – the agent produces `score`, `approved`, and `recommendation` fields automatically for vote-based strategies (not JUDGE_DECIDES).
+
+#### Yield Merge Semantics
+
+Votes and yields serve different purposes. Votes gate the transition path (`onConsensus` / `onNoConsensus`). Yields carry domain data into workflow state.
+
+| Strategy                                      | Merge behavior                                                        |
+|-----------------------------------------------|-----------------------------------------------------------------------|
+| `MAJORITY_VOTE`, `UNANIMOUS`, `WEIGHTED_VOTE` | **All** branch yields merge into state, regardless of individual vote |
+| `JUDGE_DECIDES`                               | Only the **winning** branch's yields merge into state                 |
+
+When multiple branches yield the same field name, later branches overwrite earlier ones (map merge order matches branch declaration order).
 
 #### Consensus Configuration
 
@@ -240,12 +255,12 @@ Branches without a rubric fall back to text-based heuristics (keyword detection,
 
 #### Consensus Strategies
 
-| Strategy        | Description                                                                 |
-|-----------------|-----------------------------------------------------------------------------|
-| `MAJORITY_VOTE` | Consensus when approvals >= ceil(total * threshold). Default threshold: 50% |
-| `WEIGHTED_VOTE` | Weighted approval ratio must exceed threshold. ABSTAIN votes excluded       |
-| `UNANIMOUS`     | All branches must vote APPROVE                                              |
-| `JUDGE_DECIDES` | External judge agent reviews all branch outputs and makes final decision    |
+| Strategy        | Description                                                                          |
+|-----------------|--------------------------------------------------------------------------------------|
+| `MAJORITY_VOTE` | Consensus when approvals strictly exceed `total * threshold`. Default threshold: 50% |
+| `WEIGHTED_VOTE` | Weighted approval ratio must meet or exceed threshold                                |
+| `UNANIMOUS`     | All branches must vote APPROVE                                                       |
+| `JUDGE_DECIDES` | External judge agent reviews all branch outputs and makes final decision             |
 
 ### Fork Node
 
@@ -1017,10 +1032,12 @@ fun contentPipeline() = workflow("ContentPipeline") {
             branch("quality-review") {
                 agent = "reviewer"
                 prompt = "Review for quality: {article}"
+                yields("quality_feedback")
             }
             branch("accuracy-review") {
                 agent = "reviewer"
                 prompt = "Review for accuracy: {article}"
+                yields("accuracy_feedback")
             }
 
             consensus {

--- a/docs/unified-architecture.md
+++ b/docs/unified-architecture.md
@@ -98,16 +98,16 @@ Unicode manipulation, and excessive payload size before the output is written to
 
 Workflows are not limited to linear chains. The graph engine supports:
 
-| Capability                | Mechanism                                                                                                                                                          |
-|:--------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Conditional branching** | `ScoreTransition` routes based on rubric scores; `SuccessTransition` / `FailureTransition` route on result                                                         |
-| **Loops**                 | `LoopNode` with configurable break conditions and max iterations                                                                                                   |
-| **Parallel fan-out**      | `ParallelNode` executes branches concurrently on virtual threads                                                                                                   |
-| **Fork / Join**           | `ForkNode` spawns independent parallel paths; `JoinNode` awaits and merges results                                                                                 |
-| **Consensus**             | Majority vote, unanimous, weighted vote, or judge-decides strategies                                                                                               |
-| **Backtracking**          | Review decisions can jump to any previous node, restoring state from execution history                                                                             |
-| **Sub-workflows**         | `SubWorkflowNode` with input/output mapping for hierarchical composition                                                                                           |
-| **Pause / Resume**        | Any node returning `PENDING` checkpoints state (including `PlanSnapshot` — micro-plan step index — alongside node position); `executeFrom()` resumes from snapshot |
+| Capability                | Mechanism                                                                                                                                                                                                           |
+|:--------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Conditional branching** | `ScoreTransition` routes based on rubric scores; `SuccessTransition` / `FailureTransition` route on result                                                                                                          |
+| **Loops**                 | `LoopNode` with configurable break conditions and max iterations                                                                                                                                                    |
+| **Parallel fan-out**      | `ParallelNode` executes branches concurrently on virtual threads                                                                                                                                                    |
+| **Fork / Join**           | `ForkNode` spawns independent parallel paths; `JoinNode` awaits and merges results                                                                                                                                  |
+| **Consensus**             | Majority vote, unanimous, weighted vote, or judge-decides strategies. Branches declare domain output via `yields()`. Vote strategies merge all branch yields; JUDGE_DECIDES merges only the winning branch's yields |
+| **Backtracking**          | Review decisions can jump to any previous node, restoring state from execution history                                                                                                                              |
+| **Sub-workflows**         | `SubWorkflowNode` with input/output mapping for hierarchical composition                                                                                                                                            |
+| **Pause / Resume**        | Any node returning `PENDING` checkpoints state (including `PlanSnapshot` — micro-plan step index — alongside node position); `executeFrom()` resumes from snapshot                                                  |
 
 For non-agent steps, `GenericNode` runs custom synchronous logic registered by `executorType`;
 `ActionNode` dispatches asynchronous tasks to external systems via a registered `ActionHandler`
@@ -295,9 +295,13 @@ Zero-dependency Java library. Contains:
 - `ToolRegistry` / `ToolDefinition` — Protocol-agnostic tool descriptors for MCP integration
 - `RubricEngine` / `ScoreExtractingEvaluator` — Quality evaluation: reads `score` engine variable
   from context; accumulates feedback into `recommendation`; no JSON parsing
-- `EngineVariablePromptEnricher` — Composite enricher running 5 injectors before each agent call:
+- `EngineVariables` — SSOT for engine variable names (`score`, `approved`, `recommendation`)
+- `AgentLifecycleRunner` — Composition-based agent call: prompt enrichment → execution → output extraction
+- `EngineVariablePromptEnricher` — Composite enricher running 6 injectors before each agent call:
   `RubricPromptInjector` → `ScoreVariableInjector` → `ApprovalVariableInjector` →
-  `RecommendationVariableInjector` → `WritesVariableInjector`
+  `RecommendationVariableInjector` → `WritesVariableInjector` → `YieldsVariableInjector`.
+  Score/Approval/Recommendation injectors fire for both transition-based nodes and consensus branches
+  (via `BranchExecutionConfig.needsSelfScoring()`)
 - `WorkflowRepository` / `WorkflowStateRepository` — Tenant-scoped storage interfaces with in-memory defaults
 - `HensuState` / `HensuSnapshot` / `ExecutionHistory` — Mutable runtime state, immutable checkpoints, execution trace
 - Workflow model, Node types (including `SubWorkflowNode`), Transition rules

--- a/hensu-cli/src/main/java/io/hensu/cli/daemon/DaemonFrame.java
+++ b/hensu-cli/src/main/java/io/hensu/cli/daemon/DaemonFrame.java
@@ -409,8 +409,8 @@ public final class DaemonFrame {
     /// @param allowBacktrack whether the reviewer may backtrack to a previous step
     /// @param historySteps  ordered list of completed steps for backtrack selection, not null
     /// @param workflowJson  serialized workflow JSON for prompt editing; may be null
-    /// @param context       current state context for variable display in prompt editor; may be
-    // null
+    /// @param context       current state context for variable display in prompt editor;
+    ///                      may be null
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record ReviewPayload(
             @JsonProperty("node_id") String nodeId,

--- a/hensu-cli/src/main/java/io/hensu/cli/execution/VerboseExecutionListenerFactory.java
+++ b/hensu-cli/src/main/java/io/hensu/cli/execution/VerboseExecutionListenerFactory.java
@@ -5,6 +5,7 @@ import io.hensu.core.execution.ExecutionListener;
 import io.hensu.core.workflow.Workflow;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.io.PrintStream;
 
 /// Factory for creating {@link VerboseExecutionListener} instances with CDI-injected dependencies.
 ///
@@ -29,7 +30,7 @@ public class VerboseExecutionListenerFactory {
     /// @param termWidth terminal width in columns for box-drawing alignment
     /// @return configured listener writing to {@code out}, never null
     public ExecutionListener create(
-            Workflow workflow, java.io.PrintStream out, boolean useColor, int termWidth) {
+            Workflow workflow, PrintStream out, boolean useColor, int termWidth) {
         return new VerboseExecutionListener(out, useColor, workflow, visualizer, termWidth);
     }
 }

--- a/hensu-core/README.md
+++ b/hensu-core/README.md
@@ -279,6 +279,7 @@ hensu-core/src/main/java/io/hensu/core/
 │   │   ├── DefaultNodeExecutorRegistry.java # Default implementation
 │   │   ├── NodeResult.java                # Primary return type for all node executors
 │   │   ├── ExecutionContext.java           # Per-execution context carrier (state + tenant)
+│   │   ├── AgentLifecycleRunner.java      # Composition-based agent call: enrich → execute → extract
 │   │   ├── AgenticNodeExecutor.java       # Drives preparation + execution PlanPipelines for StandardNode
 │   │   ├── StandardNodeExecutor.java      # LLM prompt execution (no planning)
 │   │   ├── ParallelNodeExecutor.java      # Concurrent branch execution
@@ -289,14 +290,16 @@ hensu-core/src/main/java/io/hensu/core/
 │   │   ├── GenericNodeExecutor.java       # Custom node handlers
 │   │   ├── SubWorkflowNodeExecutor.java   # Nested workflow execution
 │   │   └── EndNodeExecutor.java           # Terminal nodes
+│   ├── EngineVariables.java                   # SSOT for engine variable names (score, approved, recommendation)
 │   ├── enricher/
 │   │   ├── EngineVariableInjector.java        # Single-injector interface
 │   │   ├── EngineVariablePromptEnricher.java  # Composite enricher — runs injector chain before each agent call
 │   │   ├── RubricPromptInjector.java          # Injects rubric criteria when node.rubricId is set
-│   │   ├── ScoreVariableInjector.java         # Injects `score` requirement on ScoreTransition nodes
-│   │   ├── ApprovalVariableInjector.java      # Injects `approved` requirement on ApprovalTransition nodes
-│   │   ├── RecommendationVariableInjector.java # Injects `recommendation` on score/approval nodes
-│   │   └── WritesVariableInjector.java        # Injects field requirements for writes() variables with optional description hints
+│   │   ├── ScoreVariableInjector.java         # Injects `score` requirement on ScoreTransition nodes or consensus branches
+│   │   ├── ApprovalVariableInjector.java      # Injects `approved` requirement on ApprovalTransition nodes or consensus branches
+│   │   ├── RecommendationVariableInjector.java # Injects `recommendation` on score/approval nodes or consensus branches
+│   │   ├── WritesVariableInjector.java        # Injects field requirements for writes() variables with optional description hints
+│   │   └── YieldsVariableInjector.java        # Injects field requirements for branch yields() variables
 │   ├── pipeline/
 │   │   ├── NodeExecutionProcessor.java          # Base processor interface
 │   │   ├── PreNodeExecutionProcessor.java       # Pre-execution processor marker interface
@@ -326,6 +329,7 @@ hensu-core/src/main/java/io/hensu/core/
 │       ├── ConsensusConfig.java   # Consensus configuration (strategy, threshold)
 │       ├── ConsensusEvaluator.java # Evaluates branch results against consensus rules
 │       ├── ConsensusResult.java   # Outcome of consensus evaluation
+│       ├── BranchExecutionConfig.java # Typed branch metadata on ExecutionContext (consensus, yields)
 │       ├── FailureMarker.java     # Sentinel for failed branches in fork/join
 │       └── ForkJoinContext.java   # Shared fork/join state
 ├── workflow/
@@ -390,7 +394,7 @@ hensu-core/src/main/java/io/hensu/core/
 | Node              | Description                                                                                                        |
 |-------------------|--------------------------------------------------------------------------------------------------------------------|
 | `StandardNode`    | Executes an LLM prompt, optionally writes structured state variables via `writes`, and transitions based on result |
-| `ParallelNode`    | Runs multiple branches concurrently                                                                                |
+| `ParallelNode`    | Runs multiple branches concurrently; branches declare domain output via `yields()` which merge into workflow state |
 | `ForkNode`        | Splits execution into parallel paths                                                                               |
 | `JoinNode`        | Merges parallel results with configurable strategy                                                                 |
 | `LoopNode`        | Iterates until a condition or max iterations                                                                       |

--- a/hensu-core/src/main/java/io/hensu/core/execution/EngineVariables.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/EngineVariables.java
@@ -1,0 +1,56 @@
+package io.hensu.core.execution;
+
+import java.util.List;
+import java.util.Set;
+
+/// Single source of truth for engine-managed output variable names.
+///
+/// Engine variables are injected into agent prompts and extracted from agent
+/// responses automatically by the execution pipeline. They drive consensus
+/// evaluation (score, approval) and downstream routing (recommendation).
+///
+/// Developers do not declare these in {@code writes()} or {@code yields()} –
+/// the engine infers them from graph configuration (transition rules for
+/// sequential nodes, consensus config for parallel branches).
+///
+/// ### Variable contracts
+/// - **score** – numeric 0–100, drives {@code ScoreTransition} and consensus scoring
+/// - **approved** – boolean, drives {@code ApprovalTransition} and consensus voting
+/// - **recommendation** – string, justification for score/approval decisions
+///
+/// @see io.hensu.core.execution.enricher.ScoreVariableInjector
+/// @see io.hensu.core.execution.enricher.ApprovalVariableInjector
+/// @see io.hensu.core.execution.enricher.RecommendationVariableInjector
+/// @see io.hensu.core.execution.parallel.ConsensusEvaluator
+public final class EngineVariables {
+
+    /// Numeric score (0–100) for quality evaluation and consensus.
+    public static final String SCORE = "score";
+
+    /// Boolean approval flag for approval transitions and consensus voting.
+    public static final String APPROVED = "approved";
+
+    /// Justification string for score/approval decisions.
+    public static final String RECOMMENDATION = "recommendation";
+
+    /// All engine variable names used in consensus evaluation.
+    ///
+    /// These are automatically injected into consensus branch prompts and
+    /// extracted from agent output for vote determination.
+    public static final List<String> CONSENSUS_KEYS = List.of(SCORE, APPROVED, RECOMMENDATION);
+
+    private static final Set<String> ENGINE_VAR_SET = Set.of(SCORE, APPROVED, RECOMMENDATION);
+
+    private EngineVariables() {}
+
+    /// Checks whether the given name is a reserved engine variable.
+    ///
+    /// Use this to prevent user-declared {@code yields()} or {@code writes()}
+    /// from colliding with engine-managed output fields.
+    ///
+    /// @param name variable name to check, may be null
+    /// @return true if the name is a reserved engine variable
+    public static boolean isEngineVar(String name) {
+        return name != null && ENGINE_VAR_SET.contains(name);
+    }
+}

--- a/hensu-core/src/main/java/io/hensu/core/execution/SynchronizedListenerDecorator.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/SynchronizedListenerDecorator.java
@@ -1,0 +1,71 @@
+package io.hensu.core.execution;
+
+import io.hensu.core.agent.AgentResponse;
+import io.hensu.core.execution.executor.NodeResult;
+import io.hensu.core.plan.PlannedStep;
+import io.hensu.core.state.HensuState;
+import io.hensu.core.workflow.node.Node;
+import java.util.List;
+
+/// Thread-safe decorator that serialises {@link ExecutionListener} callbacks.
+///
+/// Parallel branch execution fires listener events from multiple Virtual Threads
+/// concurrently. Without synchronization, multi-line output (e.g. box-drawing in
+/// {@code VerboseExecutionListener}) interleaves across branches, producing
+/// corrupted terminal output.
+///
+/// This decorator wraps every callback in a {@code synchronized} block so that
+/// each event's full output completes atomically. Only the parallel execution
+/// path pays the synchronization cost – sequential nodes use the raw listener.
+///
+/// ### Virtual Thread safety
+/// JEP 491 (Java 24+) eliminated Virtual Thread pinning on {@code synchronized}
+/// blocks. Monitor contention on I/O-bound listener callbacks (stdout writes) is
+/// negligible for typical branch counts (3–10).
+///
+/// @see ExecutionListener
+/// @see io.hensu.core.execution.executor.ParallelNodeExecutor
+public final class SynchronizedListenerDecorator implements ExecutionListener {
+
+    private final ExecutionListener delegate;
+
+    public SynchronizedListenerDecorator(ExecutionListener delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public synchronized void onAgentStart(String nodeId, String agentId, String prompt) {
+        delegate.onAgentStart(nodeId, agentId, prompt);
+    }
+
+    @Override
+    public synchronized void onAgentComplete(
+            String nodeId, String agentId, AgentResponse response) {
+        delegate.onAgentComplete(nodeId, agentId, response);
+    }
+
+    @Override
+    public synchronized void onNodeStart(Node node) {
+        delegate.onNodeStart(node);
+    }
+
+    @Override
+    public synchronized void onNodeComplete(Node node, NodeResult result) {
+        delegate.onNodeComplete(node, result);
+    }
+
+    @Override
+    public synchronized void onPlannerStart(String nodeId, String planningPrompt) {
+        delegate.onPlannerStart(nodeId, planningPrompt);
+    }
+
+    @Override
+    public synchronized void onPlannerComplete(String nodeId, List<PlannedStep> steps) {
+        delegate.onPlannerComplete(nodeId, steps);
+    }
+
+    @Override
+    public synchronized void onCheckpoint(HensuState state) {
+        delegate.onCheckpoint(state);
+    }
+}

--- a/hensu-core/src/main/java/io/hensu/core/execution/action/CommandRegistry.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/action/CommandRegistry.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -161,7 +162,7 @@ public class CommandRegistry {
     }
 
     /// Get all registered command IDs.
-    public java.util.Set<String> getCommandIds() {
+    public Set<String> getCommandIds() {
         return Collections.unmodifiableSet(commands.keySet());
     }
 

--- a/hensu-core/src/main/java/io/hensu/core/execution/enricher/ApprovalVariableInjector.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/enricher/ApprovalVariableInjector.java
@@ -6,10 +6,10 @@ import io.hensu.core.workflow.transition.ApprovalTransition;
 
 /// Injects the `approved` boolean output requirement into the node prompt.
 ///
-/// Applied when the node has an {@link ApprovalTransition} rule. Instructs the agent
-/// to include `"approved": true` or `"approved": false` as a JSON boolean in its response.
-/// The engine does not interpret free-form text as approval intent — the agent must
-/// output a strict boolean so {@link ApprovalTransition} can route without ambiguity.
+/// Applied when the node has an {@link ApprovalTransition} rule or when executing
+/// a consensus branch that requires self-scoring (non-JUDGE_DECIDES strategies).
+/// Instructs the agent to include `"approved": true` or `"approved": false` as a
+/// JSON boolean in its response.
 ///
 /// @see EngineVariableInjector
 /// @see io.hensu.core.workflow.transition.ApprovalTransition
@@ -25,8 +25,10 @@ public final class ApprovalVariableInjector implements EngineVariableInjector {
 
     @Override
     public String inject(String prompt, Node node, ExecutionContext ctx) {
-        boolean hasApprovalTransition =
-                node.getTransitionRules().stream().anyMatch(r -> r instanceof ApprovalTransition);
-        return hasApprovalTransition ? prompt + INSTRUCTION : prompt;
+        boolean needs =
+                node.getTransitionRules().stream().anyMatch(r -> r instanceof ApprovalTransition)
+                        || (ctx.getBranchConfig() != null
+                                && ctx.getBranchConfig().needsSelfScoring());
+        return needs ? prompt + INSTRUCTION : prompt;
     }
 }

--- a/hensu-core/src/main/java/io/hensu/core/execution/enricher/BaseVariableInjector.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/enricher/BaseVariableInjector.java
@@ -1,0 +1,65 @@
+package io.hensu.core.execution.enricher;
+
+import io.hensu.core.execution.executor.ExecutionContext;
+import io.hensu.core.workflow.node.Node;
+import io.hensu.core.workflow.state.WorkflowStateSchema;
+import java.util.List;
+import java.util.Optional;
+
+/// Shared logic for injecting JSON field requirements into the prompt.
+///
+/// Iterates over a list of field names, looks up each field's description in the
+/// workflow state schema, and appends a formatted requirement block to the prompt.
+/// Subclasses provide the field names and the requirement label.
+///
+/// ### Description enrichment
+/// When the state schema declares a {@code description} for a variable, the injected
+/// requirement includes it so the LLM knows exactly what content to produce:
+///
+/// ```
+/// Engine output requirement: your JSON response MUST include:
+///   "article"        — the full written article text
+///   "recommendation" — improvement feedback for the next iteration
+/// ```
+///
+/// When no description is declared, the field name alone is emitted (graceful fallback).
+///
+/// @see WritesVariableInjector
+/// @see YieldsVariableInjector
+/// @see EngineVariableInjector
+public abstract class BaseVariableInjector implements EngineVariableInjector {
+
+    @Override
+    public final String inject(String prompt, Node node, ExecutionContext ctx) {
+        List<String> keys = keysFor(node, ctx);
+        if (keys == null || keys.isEmpty()) return prompt;
+
+        WorkflowStateSchema schema =
+                ctx.getWorkflow() != null ? ctx.getWorkflow().getStateSchema() : null;
+
+        StringBuilder fields = new StringBuilder();
+        for (String field : keys) {
+            Optional<String> desc = schema != null ? schema.descriptionOf(field) : Optional.empty();
+            fields.append("\n  \"").append(field).append("\"");
+            desc.ifPresent(d -> fields.append(" — ").append(d));
+        }
+
+        return prompt
+                + "\n\n"
+                + requirementPrefix()
+                + ": your JSON response MUST include:"
+                + fields;
+    }
+
+    /// Returns the field names to inject for the given node and context.
+    ///
+    /// @param node the node being executed, not null
+    /// @param ctx  execution context, not null
+    /// @return list of field names, or null/empty to skip injection
+    protected abstract List<String> keysFor(Node node, ExecutionContext ctx);
+
+    /// Returns the human-readable prefix for the requirement block.
+    ///
+    /// @return requirement label, e.g. "Engine output requirement"
+    protected abstract String requirementPrefix();
+}

--- a/hensu-core/src/main/java/io/hensu/core/execution/enricher/EngineVariablePromptEnricher.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/enricher/EngineVariablePromptEnricher.java
@@ -14,14 +14,17 @@ import java.util.List;
 /// {@link #DEFAULT} runs in this order:
 /// 1. {@link RubricPromptInjector} — injects rubric criteria when `node.getRubricId()` is set
 /// 2. {@link ScoreVariableInjector} — injects `score` requirement when a
-///    {@link io.hensu.core.workflow.transition.ScoreTransition} exists
+///    {@link io.hensu.core.workflow.transition.ScoreTransition} exists or consensus branch
+///    needs self-scoring
 /// 3. {@link ApprovalVariableInjector} — injects `approved` requirement when an
-///    {@link io.hensu.core.workflow.transition.ApprovalTransition} exists
+///    {@link io.hensu.core.workflow.transition.ApprovalTransition} exists or consensus branch
+///    needs self-scoring
 /// 4. {@link RecommendationVariableInjector} — injects `recommendation` requirement when a
-///    {@link io.hensu.core.workflow.transition.ScoreTransition} or
-///    {@link io.hensu.core.workflow.transition.ApprovalTransition} exists
+///    score/approval transition exists or consensus branch needs self-scoring
 /// 5. {@link WritesVariableInjector} — injects field requirements for all user-declared
 ///    {@code writes()} variables so the LLM produces extractable JSON keys
+/// 6. {@link YieldsVariableInjector} — injects field requirements for branch
+///    {@code yields()} variables so the LLM produces extractable domain output
 ///
 /// ### Extension
 /// Construct a custom enricher with additional {@link EngineVariableInjector} implementations.
@@ -40,7 +43,8 @@ public final class EngineVariablePromptEnricher {
                             new ScoreVariableInjector(),
                             new ApprovalVariableInjector(),
                             new RecommendationVariableInjector(),
-                            new WritesVariableInjector()));
+                            new WritesVariableInjector(),
+                            new YieldsVariableInjector()));
 
     private final List<EngineVariableInjector> injectors;
 

--- a/hensu-core/src/main/java/io/hensu/core/execution/enricher/RecommendationVariableInjector.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/enricher/RecommendationVariableInjector.java
@@ -7,11 +7,10 @@ import io.hensu.core.workflow.transition.ScoreTransition;
 
 /// Injects the `recommendation` string output requirement into the node prompt.
 ///
-/// Applied when the node has a {@link ScoreTransition} or {@link ApprovalTransition} rule.
-/// Both transition types imply that the agent is making a judgment — scoring content or
-/// approving/rejecting it — and must justify that judgment with improvement feedback or
-/// review reasoning. Without this field, downstream prompt variables such as
-/// `{recommendation}` resolve to empty strings and the improvement loop breaks.
+/// Applied when the node has a {@link ScoreTransition} or {@link ApprovalTransition} rule,
+/// or when executing a consensus branch that requires self-scoring (non-JUDGE_DECIDES
+/// strategies). Ensures the agent justifies its judgment with improvement feedback or
+/// review reasoning.
 ///
 /// ### Engine variable contract
 ///
@@ -37,12 +36,14 @@ public final class RecommendationVariableInjector implements EngineVariableInjec
 
     @Override
     public String inject(String prompt, Node node, ExecutionContext ctx) {
-        boolean applies =
+        boolean needs =
                 node.getTransitionRules().stream()
-                        .anyMatch(
-                                r ->
-                                        r instanceof ScoreTransition
-                                                || r instanceof ApprovalTransition);
-        return applies ? prompt + INSTRUCTION : prompt;
+                                .anyMatch(
+                                        r ->
+                                                r instanceof ScoreTransition
+                                                        || r instanceof ApprovalTransition)
+                        || (ctx.getBranchConfig() != null
+                                && ctx.getBranchConfig().needsSelfScoring());
+        return needs ? prompt + INSTRUCTION : prompt;
     }
 }

--- a/hensu-core/src/main/java/io/hensu/core/execution/enricher/ScoreVariableInjector.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/enricher/ScoreVariableInjector.java
@@ -6,9 +6,8 @@ import io.hensu.core.workflow.transition.ScoreTransition;
 
 /// Injects the `score` numeric output requirement into the node prompt.
 ///
-/// Applied when the node has a {@link ScoreTransition} rule. This includes both
-/// rubric nodes (which must always pair with an {@code onScore} transition) and
-/// self-scoring nodes without a rubric.
+/// Applied when the node has a {@link ScoreTransition} rule or when executing
+/// a consensus branch that requires self-scoring (non-JUDGE_DECIDES strategies).
 ///
 /// @see EngineVariableInjector
 /// @see io.hensu.core.workflow.transition.ScoreTransition
@@ -24,8 +23,10 @@ public final class ScoreVariableInjector implements EngineVariableInjector {
 
     @Override
     public String inject(String prompt, Node node, ExecutionContext ctx) {
-        boolean hasScoreTransition =
-                node.getTransitionRules().stream().anyMatch(r -> r instanceof ScoreTransition);
-        return hasScoreTransition ? prompt + INSTRUCTION : prompt;
+        boolean needs =
+                node.getTransitionRules().stream().anyMatch(r -> r instanceof ScoreTransition)
+                        || (ctx.getBranchConfig() != null
+                                && ctx.getBranchConfig().needsSelfScoring());
+        return needs ? prompt + INSTRUCTION : prompt;
     }
 }

--- a/hensu-core/src/main/java/io/hensu/core/execution/enricher/WritesVariableInjector.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/enricher/WritesVariableInjector.java
@@ -3,9 +3,7 @@ package io.hensu.core.execution.enricher;
 import io.hensu.core.execution.executor.ExecutionContext;
 import io.hensu.core.workflow.node.Node;
 import io.hensu.core.workflow.node.StandardNode;
-import io.hensu.core.workflow.state.WorkflowStateSchema;
 import java.util.List;
-import java.util.Optional;
 
 /// Injects JSON field requirements for user-declared {@code writes()} variables into the prompt.
 ///
@@ -15,48 +13,24 @@ import java.util.Optional;
 /// {@link io.hensu.core.execution.pipeline.OutputExtractionPostProcessor} cannot extract them,
 /// leaving downstream prompt variables empty (e.g. {@code {article}} resolves to an empty string).
 ///
-/// ### Description enrichment
-/// When the workflow state schema declares a {@code description} for a variable, the injected
-/// requirement includes it so the LLM knows exactly what content to produce:
-///
-/// ```
-/// Engine output requirement: your JSON response MUST include:
-///   "article"        — the full written article text
-///   "recommendation" — improvement feedback for the next iteration
-/// ```
-///
-/// When no description is declared, the field name alone is emitted (graceful fallback).
-///
-/// ### Placement in the pipeline
-/// Runs last in {@link EngineVariablePromptEnricher#DEFAULT}, after
-/// {@link ScoreVariableInjector} and {@link ApprovalVariableInjector}, so all engine-level
-/// format requirements are co-located at the end of the prompt.
-///
 /// ### Skipped when
 /// - The node has no {@code writes()} declarations, or
 /// - The node is not a {@link StandardNode}.
 ///
-/// @see EngineVariableInjector
+/// @see BaseVariableInjector
 /// @see io.hensu.core.execution.pipeline.OutputExtractionPostProcessor
 /// @see io.hensu.core.workflow.state.StateVariableDeclaration#description()
-public final class WritesVariableInjector implements EngineVariableInjector {
+public final class WritesVariableInjector extends BaseVariableInjector {
 
     @Override
-    public String inject(String prompt, Node node, ExecutionContext ctx) {
-        if (!(node instanceof StandardNode sn)) return prompt;
+    protected List<String> keysFor(Node node, ExecutionContext ctx) {
+        if (!(node instanceof StandardNode sn)) return List.of();
         List<String> writes = sn.getWrites();
-        if (writes == null || writes.isEmpty()) return prompt;
+        return writes != null ? writes : List.of();
+    }
 
-        WorkflowStateSchema schema =
-                ctx.getWorkflow() != null ? ctx.getWorkflow().getStateSchema() : null;
-
-        StringBuilder fields = new StringBuilder();
-        for (String field : writes) {
-            Optional<String> desc = schema != null ? schema.descriptionOf(field) : Optional.empty();
-            fields.append("\n  \"").append(field).append("\"");
-            desc.ifPresent(d -> fields.append(" — ").append(d));
-        }
-
-        return prompt + "\n\nEngine output requirement: your JSON response MUST include:" + fields;
+    @Override
+    protected String requirementPrefix() {
+        return "Engine output requirement";
     }
 }

--- a/hensu-core/src/main/java/io/hensu/core/execution/enricher/YieldsVariableInjector.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/enricher/YieldsVariableInjector.java
@@ -1,0 +1,37 @@
+package io.hensu.core.execution.enricher;
+
+import io.hensu.core.execution.executor.ExecutionContext;
+import io.hensu.core.execution.parallel.BranchExecutionConfig;
+import io.hensu.core.workflow.node.Node;
+import java.util.List;
+
+/// Injects JSON field requirements for branch {@code yields()} variables into the prompt.
+///
+/// When a parallel branch declares output variables via {@code yields("api_schema", "summary")},
+/// the LLM must be explicitly told to include those exact fields in its JSON response so
+/// the extraction pipeline can pull them out.
+///
+/// The yields list is read from the typed {@link BranchExecutionConfig} on the
+/// {@link ExecutionContext}, set by {@code ParallelNodeExecutor} before branch enrichment.
+///
+/// ### Skipped when
+/// - No branch config on the execution context, or
+/// - The yields list is empty.
+///
+/// @see BaseVariableInjector
+/// @see BranchExecutionConfig
+/// @see io.hensu.core.execution.pipeline.OutputExtractionPostProcessor
+public final class YieldsVariableInjector extends BaseVariableInjector {
+
+    @Override
+    protected List<String> keysFor(Node node, ExecutionContext ctx) {
+        BranchExecutionConfig config = ctx.getBranchConfig();
+        if (config == null) return List.of();
+        return config.yields();
+    }
+
+    @Override
+    protected String requirementPrefix() {
+        return "Engine yield requirement";
+    }
+}

--- a/hensu-core/src/main/java/io/hensu/core/execution/executor/AgentLifecycleRunner.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/executor/AgentLifecycleRunner.java
@@ -1,0 +1,97 @@
+package io.hensu.core.execution.executor;
+
+import io.hensu.core.agent.Agent;
+import io.hensu.core.agent.AgentResponse;
+import io.hensu.core.execution.ExecutionListener;
+import io.hensu.core.execution.enricher.EngineVariablePromptEnricher;
+import io.hensu.core.execution.result.ResultStatus;
+import io.hensu.core.workflow.node.Node;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/// Stateless runner encapsulating the core agent execution lifecycle.
+///
+/// Centralizes the shared sequence that both {@link StandardNodeExecutor} and
+/// {@link ParallelNodeExecutor} need when invoking an LLM agent:
+///
+/// 1. Template resolution – replace `{variable}` placeholders in the prompt
+/// 2. Prompt enrichment – inject engine variable and yield field requirements
+/// 3. Agent lookup – resolve the agent instance from the registry
+/// 4. Listener notification – fire {@code onAgentStart} / {@code onAgentComplete}
+/// 5. Agent execution – call the LLM
+/// 6. Response conversion – map {@link AgentResponse} to {@link NodeResult}
+///
+/// This class owns **only** the agent call path. Output validation, output
+/// extraction (writes / yields), transition resolution, and history recording
+/// remain with their respective owners.
+///
+/// @implNote Package-private, stateless, no instances. Safe to call from any
+/// thread including Virtual Threads.
+final class AgentLifecycleRunner {
+
+    private static final Logger logger = Logger.getLogger(AgentLifecycleRunner.class.getName());
+
+    private AgentLifecycleRunner() {}
+
+    /// Executes the full agent call lifecycle and returns the raw result.
+    ///
+    /// @param eventSourceId  identifier used in listener events (node ID or composite branch ID)
+    /// @param agentId        identifier of the agent to invoke, not null
+    /// @param resolvedPrompt prompt with `{variable}` placeholders already resolved by the caller,
+    ///                       may be empty but not null
+    /// @param enricherTarget the node passed to prompt enrichers for inspection, not null
+    /// @param ctx            execution context carrying state, services, and branch config,
+    ///                       not null
+    /// @return node result with status and agent output, never null
+    static NodeResult execute(
+            String eventSourceId,
+            String agentId,
+            String resolvedPrompt,
+            Node enricherTarget,
+            ExecutionContext ctx) {
+
+        // 1. Prompt enrichment (engine variables, yield requirements, consensus fields)
+        String resolved =
+                EngineVariablePromptEnricher.DEFAULT.enrich(resolvedPrompt, enricherTarget, ctx);
+
+        // 2. Agent lookup
+        Agent agent =
+                ctx.getAgentRegistry()
+                        .getAgent(agentId)
+                        .orElseThrow(
+                                () -> new IllegalStateException("Agent not found: " + agentId));
+
+        logger.info("Executing agent: " + agentId + " for " + eventSourceId);
+
+        // 3. Listener events + execution
+        ExecutionListener listener = ctx.getListener();
+        listener.onAgentStart(eventSourceId, agentId, resolved);
+        AgentResponse response = agent.execute(resolved, ctx.getState().getContext());
+        listener.onAgentComplete(eventSourceId, agentId, response);
+
+        // 4. Response conversion
+        return toNodeResult(response);
+    }
+
+    private static NodeResult toNodeResult(AgentResponse response) {
+        return switch (response) {
+            case AgentResponse.TextResponse t ->
+                    new NodeResult(ResultStatus.SUCCESS, t.content(), t.metadata());
+            case AgentResponse.ToolRequest t ->
+                    new NodeResult(
+                            ResultStatus.SUCCESS,
+                            "Tool: " + t.toolName(),
+                            Map.of("toolName", t.toolName(), "arguments", t.arguments()));
+            case AgentResponse.PlanProposal p ->
+                    new NodeResult(
+                            ResultStatus.SUCCESS,
+                            "Plan with " + p.steps().size() + " steps",
+                            Map.of("steps", p.steps()));
+            case AgentResponse.Error e ->
+                    new NodeResult(
+                            ResultStatus.FAILURE,
+                            e.message(),
+                            Map.of("errorType", e.errorType().name()));
+        };
+    }
+}

--- a/hensu-core/src/main/java/io/hensu/core/execution/executor/ExecutionContext.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/executor/ExecutionContext.java
@@ -4,6 +4,7 @@ import io.hensu.core.agent.AgentRegistry;
 import io.hensu.core.execution.ExecutionListener;
 import io.hensu.core.execution.WorkflowExecutor;
 import io.hensu.core.execution.action.ActionExecutor;
+import io.hensu.core.execution.parallel.BranchExecutionConfig;
 import io.hensu.core.rubric.RubricEngine;
 import io.hensu.core.state.HensuState;
 import io.hensu.core.template.TemplateResolver;
@@ -33,7 +34,8 @@ import java.util.concurrent.ExecutorService;
 /// - `workflowRepository` - For loading sub-workflow definitions
 ///
 /// @implNote Immutable after construction. Thread-safe for read access.
-/// Modified copies can be created via {@link #withState} and {@link #withWorkflow}.
+/// Modified copies can be created via {@link #withState}, {@link #withListener},
+/// and {@link #withBranchConfig}.
 ///
 /// @see NodeExecutor for node execution logic
 /// @see WorkflowExecutor for main execution loop
@@ -43,6 +45,9 @@ public final class ExecutionContext {
     private final HensuState state;
     private final Workflow workflow;
     private final ExecutionListener listener;
+
+    // Branch execution metadata - null when not executing a parallel branch
+    private final BranchExecutionConfig branchConfig;
 
     // Services - provided by registry, executors pull what they need
     private final AgentRegistry agentRegistry;
@@ -58,6 +63,7 @@ public final class ExecutionContext {
         this.state = builder.state;
         this.workflow = builder.workflow;
         this.listener = builder.listener;
+        this.branchConfig = builder.branchConfig;
         this.agentRegistry = builder.agentRegistry;
         this.templateResolver = builder.templateResolver;
         this.executorService = builder.executorService;
@@ -149,6 +155,18 @@ public final class ExecutionContext {
         return workflowRepository;
     }
 
+    /// Returns the branch execution configuration, if executing inside a parallel branch.
+    ///
+    /// Non-null only during branch execution within {@code ParallelNodeExecutor}.
+    /// Enrichers use this to detect consensus branches and read yield declarations
+    /// without polluting the user-visible state context map.
+    ///
+    /// @return branch config, or null if not executing a branch
+    /// @see BranchExecutionConfig
+    public BranchExecutionConfig getBranchConfig() {
+        return branchConfig;
+    }
+
     /// Creates a new context builder.
     ///
     /// @return new builder instance, never null
@@ -168,6 +186,7 @@ public final class ExecutionContext {
                 .state(newState)
                 .workflow(this.workflow)
                 .listener(this.listener)
+                .branchConfig(this.branchConfig)
                 .agentRegistry(this.agentRegistry)
                 .templateResolver(this.templateResolver)
                 .executorService(this.executorService)
@@ -179,18 +198,43 @@ public final class ExecutionContext {
                 .build();
     }
 
-    /// Creates a child context with a different workflow.
+    /// Creates a child context with a different listener.
     ///
-    /// Used for sub-workflow invocation where the workflow definition
-    /// changes but services remain the same.
+    /// Used by {@code ParallelNodeExecutor} to wrap the listener in a
+    /// thread-safe decorator for concurrent branch execution.
     ///
-    /// @param newWorkflow the new workflow definition, not null
-    /// @return new context with updated workflow, never null
-    public ExecutionContext withWorkflow(Workflow newWorkflow) {
+    /// @param newListener the new execution listener, not null
+    /// @return new context with updated listener, never null
+    public ExecutionContext withListener(ExecutionListener newListener) {
         return builder()
                 .state(this.state)
-                .workflow(newWorkflow)
+                .workflow(this.workflow)
+                .listener(newListener)
+                .branchConfig(this.branchConfig)
+                .agentRegistry(this.agentRegistry)
+                .templateResolver(this.templateResolver)
+                .executorService(this.executorService)
+                .nodeExecutorRegistry(this.nodeExecutorRegistry)
+                .workflowExecutor(this.workflowExecutor)
+                .actionExecutor(this.actionExecutor)
+                .rubricEngine(this.rubricEngine)
+                .workflowRepository(this.workflowRepository)
+                .build();
+    }
+
+    /// Creates a child context with branch execution metadata.
+    ///
+    /// Used by {@code ParallelNodeExecutor} to attach branch-specific config
+    /// (consensus flag, yield declarations) without polluting the state context map.
+    ///
+    /// @param config branch execution configuration, may be null to clear
+    /// @return new context with branch config set, never null
+    public ExecutionContext withBranchConfig(BranchExecutionConfig config) {
+        return builder()
+                .state(this.state)
+                .workflow(this.workflow)
                 .listener(this.listener)
+                .branchConfig(config)
                 .agentRegistry(this.agentRegistry)
                 .templateResolver(this.templateResolver)
                 .executorService(this.executorService)
@@ -211,6 +255,7 @@ public final class ExecutionContext {
         private HensuState state;
         private Workflow workflow;
         private ExecutionListener listener = ExecutionListener.NOOP;
+        private BranchExecutionConfig branchConfig;
         private AgentRegistry agentRegistry;
         private TemplateResolver templateResolver;
         private ExecutorService executorService;
@@ -234,6 +279,11 @@ public final class ExecutionContext {
 
         public Builder listener(ExecutionListener listener) {
             this.listener = listener != null ? listener : ExecutionListener.NOOP;
+            return this;
+        }
+
+        public Builder branchConfig(BranchExecutionConfig branchConfig) {
+            this.branchConfig = branchConfig;
             return this;
         }
 

--- a/hensu-core/src/main/java/io/hensu/core/execution/executor/ParallelNodeExecutor.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/executor/ParallelNodeExecutor.java
@@ -1,24 +1,17 @@
 package io.hensu.core.execution.executor;
 
-import io.hensu.core.agent.Agent;
 import io.hensu.core.agent.AgentRegistry;
-import io.hensu.core.agent.AgentResponse;
-import io.hensu.core.execution.parallel.Branch;
-import io.hensu.core.execution.parallel.BranchResult;
-import io.hensu.core.execution.parallel.ConsensusConfig;
-import io.hensu.core.execution.parallel.ConsensusEvaluator;
-import io.hensu.core.execution.parallel.ConsensusResult;
-import io.hensu.core.execution.parallel.FailureMarker;
+import io.hensu.core.execution.EngineVariables;
+import io.hensu.core.execution.ExecutionListener;
+import io.hensu.core.execution.SynchronizedListenerDecorator;
+import io.hensu.core.execution.parallel.*;
+import io.hensu.core.execution.result.ExecutionHistory;
 import io.hensu.core.execution.result.ResultStatus;
-import io.hensu.core.rubric.RubricEngine;
-import io.hensu.core.rubric.RubricParser;
-import io.hensu.core.rubric.evaluator.RubricEvaluation;
-import io.hensu.core.rubric.model.Rubric;
 import io.hensu.core.state.HensuState;
 import io.hensu.core.template.TemplateResolver;
-import io.hensu.core.workflow.Workflow;
+import io.hensu.core.util.AgentOutputValidator;
+import io.hensu.core.util.JsonUtil;
 import io.hensu.core.workflow.node.ParallelNode;
-import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -27,38 +20,51 @@ import java.util.stream.Collectors;
 
 /// Executes parallel nodes by running multiple branches concurrently.
 ///
-/// ### This executor
+/// ### Branch isolation
+/// Each branch runs on its own virtual thread with an isolated context snapshot
+/// bound via {@link ScopedValue}. Branch mutations never leak into sibling
+/// branches or the parent state.
 ///
-/// - Each branch receives an **isolated snapshot** of the parent context map — writes
-///   inside a branch agent do not race or leak into sibling branches or the parent state
-/// - Executes branches in parallel using `ExecutorService`
-/// - Evaluates branch outputs against rubrics when `Branch.rubricId` is set
-/// - Aggregates results from all branches
-/// - Evaluates consensus if configured (majority, unanimous, weighted, judge)
+/// ### Agent lifecycle delegation
+/// Branch agent execution is delegated to {@link AgentLifecycleRunner}, sharing
+/// the same template resolution, prompt enrichment, listener notification, and
+/// response conversion path as {@link StandardNodeExecutor}. Branch-specific
+/// concerns (output validation, yield extraction) remain here.
 ///
-/// ### Rubric Integration
-/// When a branch declares a `rubricId`, the executor evaluates the branch output against
-/// the rubric **after all branch futures resolve**, sequentially on the coordinator thread.
-/// The rubric score and pass/fail status are stored in branch result metadata
-/// (`rubric_score`, `rubric_passed`), where they take priority over text-parsing heuristics
-/// during consensus voting.
+/// ### Thread-safe listener
+/// The parent {@link io.hensu.core.execution.ExecutionListener} is wrapped in a
+/// {@link SynchronizedListenerDecorator} before branch submission so that
+/// multi-line output (e.g. box-drawing in verbose CLI) does not interleave
+/// across concurrent branches.
 ///
-/// ### Consensus Strategies
-/// - `MAJORITY_VOTE` — branch with the most approval votes wins
-/// - `UNANIMOUS` — all branches must agree
-/// - `WEIGHTED_VOTE` — votes are weighted by `Branch.weight`
-/// - `JUDGE_DECIDES` — a judge agent resolves disagreement; runs on coordinator thread
+/// ### Yields merge
+/// After consensus evaluation, only winning branches' yields are promoted to
+/// {@code state.getContext()}. Loser yields are preserved in consensus metadata
+/// for observability but never touch the live context.
 ///
-/// @implNote The `ExecutorService` is obtained from `ExecutionContext` and is NOT shut down
-/// by this executor — lifecycle is managed by the owner. Consensus and rubric evaluation
-/// run sequentially on the coordinator thread after all branch futures resolve.
+/// ### Branch execution metadata
+/// Branch-specific config (consensus flag, yield declarations) is carried on
+/// {@link ExecutionContext#getBranchConfig()} – NOT in the state context map.
+/// This keeps engine-internal flags out of the user data bus and invisible to
+/// the LLM agent.
 ///
+/// @implNote The {@code ExecutorService} is obtained from {@code ExecutionContext}
+/// and is NOT shut down by this executor – lifecycle is managed by the owner.
+///
+/// @see AgentLifecycleRunner for the shared agent call lifecycle
 /// @see ConsensusEvaluator for vote extraction and strategy evaluation
-/// @see RubricEngine for rubric-based quality evaluation
-/// @see HensuState#branch for the branch isolation mechanism
+/// @see BranchExecutionConfig for branch execution metadata
 public class ParallelNodeExecutor implements NodeExecutor<ParallelNode> {
 
     private static final Logger logger = Logger.getLogger(ParallelNodeExecutor.class.getName());
+
+    /// Default branch execution timeout in seconds.
+    private static final long DEFAULT_TIMEOUT_SECONDS = 300L;
+
+    /// Branch-scoped context bound per virtual thread. Enrichers and extractors
+    /// can read {@code BRANCH_CONTEXT.get()} without explicit parameter drilling.
+    public static final ScopedValue<Map<String, Object>> BRANCH_CONTEXT = ScopedValue.newInstance();
+
     private final ConsensusEvaluator consensusEvaluator = new ConsensusEvaluator();
 
     @Override
@@ -69,77 +75,193 @@ public class ParallelNodeExecutor implements NodeExecutor<ParallelNode> {
     @Override
     public NodeResult execute(ParallelNode node, ExecutionContext context) throws Exception {
         HensuState state = context.getState();
-        AgentRegistry agentRegistry = context.getAgentRegistry();
         ExecutorService executorService = context.getExecutorService();
-        TemplateResolver templateResolver = context.getTemplateResolver();
 
         logger.info(
                 "Executing parallel node: "
                         + node.getId()
                         + " with "
-                        + (node.getBranches().length - 1)
+                        + node.getBranches().length
                         + " branches");
 
-        // TODO: Make configurable via ParallelNode or ConsensusConfig
-        // Default timeout: 5 minutes per branch
-        long timeoutSeconds = 300L;
+        // Wrap listener for thread-safe output during parallel branch execution
+        ExecutionContext safeContext =
+                context.withListener(new SynchronizedListenerDecorator(context.getListener()));
 
         List<Future<BranchResult>> futures =
                 Arrays.stream(node.getBranches())
                         .map(
-                                branch -> {
-                                    // Isolated context snapshot per branch — branch agent
-                                    // output does not race or leak into sibling branches
-                                    Map<String, Object> branchContext =
-                                            new HashMap<>(state.getContext());
-                                    return executorService.submit(
-                                            () -> {
-                                                String agentId = branch.getAgentId();
-                                                Agent agent =
-                                                        agentRegistry
-                                                                .getAgent(agentId)
-                                                                .orElseThrow(
-                                                                        () ->
-                                                                                new IllegalStateException(
-                                                                                        "Agent not found: "
-                                                                                                + agentId));
-                                                String resolvedPrompt =
-                                                        branch.getPrompt() != null
-                                                                ? templateResolver.resolve(
-                                                                        branch.getPrompt(),
-                                                                        branchContext)
-                                                                : "";
-
-                                                logger.info("Executing branch: " + branch.getId());
-
-                                                AgentResponse response =
-                                                        agent.execute(
-                                                                resolvedPrompt, branchContext);
-
-                                                return new BranchResult(
-                                                        branch.getId(), toNodeResult(response));
-                                            });
-                                })
+                                branch ->
+                                        executorService.submit(
+                                                () -> executeBranch(branch, node, safeContext)))
                         .toList();
 
-        // Collect results with timeout and partial failure handling
-        List<BranchResult> branchResults = new ArrayList<>();
-        List<String> failedBranches = new ArrayList<>();
+        List<BranchResult> branchResults = collectResults(futures, node, DEFAULT_TIMEOUT_SECONDS);
+
+        if (branchResults.stream()
+                .anyMatch(br -> br.getResult().getStatus() == ResultStatus.FAILURE)) {
+            List<String> failed =
+                    branchResults.stream()
+                            .filter(br -> br.getResult().getStatus() == ResultStatus.FAILURE)
+                            .map(BranchResult::getBranchId)
+                            .toList();
+            logger.warning("Partial failures in parallel execution: " + failed);
+            state.getContext().put("failed_branches", failed);
+        }
+
+        NodeResult finalResult;
+        if (node.getConsensusConfig() != null) {
+            finalResult =
+                    evaluateConsensus(
+                            node.getConsensusConfig(),
+                            branchResults,
+                            state,
+                            context.getAgentRegistry(),
+                            safeContext.getListener());
+        } else {
+            finalResult = aggregateResults(branchResults);
+        }
+
+        logger.info("Parallel execution completed: " + node.getId());
+        return finalResult;
+    }
+
+    // -- Branch execution --------------------------------------------------------
+
+    /// Executes a single branch with isolated context and shared agent lifecycle.
+    ///
+    /// The branch context is isolated via {@link ScopedValue} binding. Agent
+    /// execution is delegated to {@link AgentLifecycleRunner} (template resolution,
+    /// prompt enrichment, listener events, response conversion). Branch-specific
+    /// concerns (output validation, yield extraction) remain here.
+    private BranchResult executeBranch(Branch branch, ParallelNode node, ExecutionContext context) {
+
+        HensuState parentState = context.getState();
+        HashMap<String, Object> branchSnapshot = new HashMap<>(parentState.getContext());
+
+        // Branch execution config on ExecutionContext – NOT in the context map.
+        // This keeps engine flags invisible to the LLM agent.
+        ConsensusConfig cc = node.getConsensusConfig();
+        BranchExecutionConfig branchConfig =
+                new BranchExecutionConfig(
+                        cc != null, cc != null ? cc.getStrategy() : null, branch.getYields());
+
+        return ScopedValue.where(BRANCH_CONTEXT, branchSnapshot)
+                .call(
+                        () -> {
+                            HensuState branchState =
+                                    new HensuState(
+                                            branchSnapshot,
+                                            parentState.getWorkflowId(),
+                                            parentState.getCurrentNode(),
+                                            new ExecutionHistory());
+                            ExecutionContext branchCtx =
+                                    context.withState(branchState).withBranchConfig(branchConfig);
+
+                            String branchNodeId = node.getId() + "/" + branch.getId();
+
+                            // Resolve template against branch-isolated snapshot
+                            TemplateResolver resolver = branchCtx.getTemplateResolver();
+                            String resolvedPrompt =
+                                    branch.getPrompt() != null
+                                            ? resolver.resolve(branch.getPrompt(), branchSnapshot)
+                                            : "";
+
+                            // Delegate to shared agent execution lifecycle
+                            NodeResult nodeResult =
+                                    AgentLifecycleRunner.execute(
+                                            branchNodeId,
+                                            branch.getAgentId(),
+                                            resolvedPrompt,
+                                            node,
+                                            branchCtx);
+
+                            // Validate output before extraction (same safety contract as
+                            // OutputExtractionPostProcessor for sequential nodes)
+                            if (nodeResult.getOutput() != null) {
+                                String output = nodeResult.getOutput().toString();
+                                Optional<String> violation = AgentOutputValidator.validate(output);
+                                if (violation.isPresent()) {
+                                    logger.warning(
+                                            "Branch ["
+                                                    + branch.getId()
+                                                    + "] output rejected: "
+                                                    + violation.get());
+                                    return new BranchResult(
+                                            branch.getId(),
+                                            new NodeResult(
+                                                    ResultStatus.FAILURE,
+                                                    "Branch output " + violation.get(),
+                                                    Map.of("error", "output_validation_failed")),
+                                            Map.of(),
+                                            branch.getWeight());
+                                }
+                            }
+
+                            // Extract structured yields from agent output
+                            Map<String, Object> yields =
+                                    extractBranchYields(branch, node, nodeResult, branchSnapshot);
+
+                            return new BranchResult(
+                                    branch.getId(), nodeResult, yields, branch.getWeight());
+                        });
+    }
+
+    /// Extracts structured output from branch agent response into a yields map.
+    ///
+    /// Uses the same {@link JsonUtil#extractOutputParams} path as
+    /// {@link io.hensu.core.execution.pipeline.OutputExtractionPostProcessor}.
+    /// Extracts both domain yields declared via {@code yields()} and engine
+    /// variables (via {@link EngineVariables#CONSENSUS_KEYS}) for consensus
+    /// evaluation.
+    private Map<String, Object> extractBranchYields(
+            Branch branch,
+            ParallelNode node,
+            NodeResult result,
+            Map<String, Object> branchContext) {
+
+        if (result.getOutput() == null) return Map.of();
+
+        String output = result.getOutput().toString();
+        List<String> allKeys = new ArrayList<>(branch.getYields());
+
+        ConsensusConfig branchCC = node.getConsensusConfig();
+        if (branchCC != null && branchCC.getStrategy() != ConsensusStrategy.JUDGE_DECIDES) {
+            allKeys.addAll(EngineVariables.CONSENSUS_KEYS);
+        }
+
+        if (allKeys.isEmpty()) return Map.of();
+
+        // Extract into branch context (same as OutputExtractionPostProcessor)
+        JsonUtil.extractOutputParams(allKeys, output, branchContext, logger);
+
+        // Package extracted values into yields map
+        Map<String, Object> yields = new HashMap<>();
+        for (String key : allKeys) {
+            if (branchContext.containsKey(key)) {
+                yields.put(key, branchContext.get(key));
+            }
+        }
+        return yields;
+    }
+
+    // -- Result collection -------------------------------------------------------
+
+    private List<BranchResult> collectResults(
+            List<Future<BranchResult>> futures, ParallelNode node, long timeoutSeconds) {
+
+        List<BranchResult> results = new ArrayList<>();
 
         for (int i = 0; i < futures.size(); i++) {
             Future<BranchResult> future = futures.get(i);
             String branchId = node.getBranches()[i].getId();
 
             try {
-                BranchResult result =
-                        future.get(timeoutSeconds, java.util.concurrent.TimeUnit.SECONDS);
-                branchResults.add(result);
+                results.add(future.get(timeoutSeconds, java.util.concurrent.TimeUnit.SECONDS));
             } catch (java.util.concurrent.TimeoutException e) {
                 logger.warning("Branch timed out after " + timeoutSeconds + "s: " + branchId);
-                failedBranches.add(branchId + " (timeout)");
                 future.cancel(true);
-                // Add failure result for timed-out branch
-                branchResults.add(
+                results.add(
                         new BranchResult(
                                 branchId,
                                 new NodeResult(
@@ -147,14 +269,8 @@ public class ParallelNodeExecutor implements NodeExecutor<ParallelNode> {
                                         "Branch timed out",
                                         Map.of("error", "timeout"))));
             } catch (java.util.concurrent.ExecutionException e) {
-                logger.warning(
-                        "Branch failed with exception: "
-                                + branchId
-                                + " - "
-                                + e.getCause().getMessage());
-                failedBranches.add(branchId + " (" + e.getCause().getClass().getSimpleName() + ")");
-                // Add failure result for failed branch
-                branchResults.add(
+                logger.warning("Branch failed: " + branchId + " - " + e.getCause().getMessage());
+                results.add(
                         new BranchResult(
                                 branchId,
                                 new NodeResult(
@@ -171,229 +287,64 @@ public class ParallelNodeExecutor implements NodeExecutor<ParallelNode> {
             }
         }
 
-        if (!failedBranches.isEmpty()) {
-            logger.warning("Partial failures in parallel execution: " + failedBranches);
-            state.getContext().put("failed_branches", failedBranches);
-        }
-
-        // Inject branch-level weights into result metadata for ConsensusEvaluator
-        branchResults = enrichWithBranchWeights(branchResults, node);
-
-        // Evaluate branch rubrics before consensus (rubric scores override text heuristics)
-        branchResults = enrichWithRubricScores(branchResults, node, context);
-
-        // Consensus evaluation if configured
-        NodeResult finalResult;
-        if (node.getConsensusConfig() != null) {
-            finalResult =
-                    evaluateConsensus(
-                            node.getConsensusConfig(), branchResults, state, agentRegistry);
-        } else {
-            // No consensus — aggregate all branch results.
-            // A SUCCESS branch with null output is a structural anomaly and is treated as
-            // failed; downstream nodes can pattern-match on FailureMarker to distinguish.
-            boolean allSuccess = true;
-            Map<String, Object> outputs = new LinkedHashMap<>();
-            for (BranchResult br : branchResults) {
-                NodeResult result = br.getResult();
-                if (result.getStatus() == ResultStatus.SUCCESS && result.getOutput() != null) {
-                    outputs.put(br.getBranchId(), result.getOutput());
-                } else {
-                    allSuccess = false;
-                    String msg =
-                            result.getOutput() != null
-                                    ? result.getOutput().toString()
-                                    : "Branch returned null output";
-                    outputs.put(br.getBranchId(), new FailureMarker(msg));
-                }
-            }
-
-            Map<String, Object> metadata = new HashMap<>();
-            metadata.put("branch_count", branchResults.size());
-
-            finalResult =
-                    new NodeResult(
-                            allSuccess ? ResultStatus.SUCCESS : ResultStatus.FAILURE,
-                            outputs,
-                            metadata);
-        }
-
-        logger.info("Parallel execution completed: " + node.getId());
-        return finalResult;
+        return results;
     }
 
-    /// Injects branch-level weights from the node definition into result metadata.
-    ///
-    /// The {@link ConsensusEvaluator} reads `"weight"` from result metadata during
-    /// vote extraction. This method propagates the weight declared in each
-    /// {@link Branch} definition so that DSL-configured weights reach the evaluator.
-    ///
-    /// @param branchResults collected branch execution results, not null
-    /// @param node the parallel node containing branch definitions, not null
-    /// @return branch results with weight metadata injected, never null
-    private List<BranchResult> enrichWithBranchWeights(
-            List<BranchResult> branchResults, ParallelNode node) {
+    // -- Result aggregation (no consensus) ---------------------------------------
 
-        Map<String, Branch> branchMap = new HashMap<>();
-        for (Branch branch : node.getBranches()) {
-            branchMap.put(branch.getId(), branch);
-        }
-
-        List<BranchResult> enriched = new ArrayList<>(branchResults.size());
-        for (BranchResult br : branchResults) {
-            Branch branch = branchMap.get(br.getBranchId());
-            if (branch != null && branch.getWeight() != 1.0) {
-                Map<String, Object> metadata = new HashMap<>(br.getResult().getMetadata());
-                metadata.put("weight", branch.getWeight());
-                NodeResult enrichedResult =
-                        new NodeResult(
-                                br.getResult().getStatus(), br.getResult().getOutput(), metadata);
-                enriched.add(new BranchResult(br.getBranchId(), enrichedResult));
-            } else {
-                enriched.add(br);
-            }
-        }
-        return enriched;
-    }
-
-    /// Evaluates branch outputs against rubrics and enriches result metadata.
-    ///
-    /// For each branch that declares a `rubricId` and completed successfully,
-    /// evaluates the output against the rubric and stores `rubric_score`,
-    /// `rubric_passed`, and `rubric_id` in the result metadata. These metadata
-    /// fields take priority over text-parsing heuristics in
-    /// {@link ConsensusEvaluator#extractVotes}.
-    ///
-    /// Branches without a rubricId or with non-SUCCESS status are returned unchanged.
-    /// Rubric evaluation failures are logged and the original result is preserved.
-    ///
-    /// @param branchResults collected branch execution results, not null
-    /// @param node the parallel node containing branch definitions, not null
-    /// @param context execution context with rubric engine and workflow, not null
-    /// @return enriched branch results with rubric metadata where applicable, never null
-    private List<BranchResult> enrichWithRubricScores(
-            List<BranchResult> branchResults, ParallelNode node, ExecutionContext context) {
-
-        RubricEngine rubricEngine = context.getRubricEngine();
-        if (rubricEngine == null) {
-            return branchResults;
-        }
-
-        Map<String, Branch> branchMap = new HashMap<>();
-        for (Branch branch : node.getBranches()) {
-            branchMap.put(branch.getId(), branch);
-        }
-
-        Workflow workflow = context.getWorkflow();
-        List<BranchResult> enriched = new ArrayList<>(branchResults.size());
+    private NodeResult aggregateResults(List<BranchResult> branchResults) {
+        boolean allSuccess = true;
+        Map<String, Object> outputs = new LinkedHashMap<>();
 
         for (BranchResult br : branchResults) {
-            Branch branch = branchMap.get(br.getBranchId());
-
-            if (branch != null
-                    && branch.rubricId() != null
-                    && br.getResult().getStatus() == ResultStatus.SUCCESS) {
-
-                String rubricId = branch.rubricId();
-                try {
-                    registerRubricIfAbsent(rubricEngine, rubricId, workflow);
-
-                    RubricEvaluation evaluation =
-                            rubricEngine.evaluate(
-                                    rubricId, br.getResult(), context.getState().getContext());
-
-                    Map<String, Object> enrichedMetadata =
-                            new HashMap<>(br.getResult().getMetadata());
-                    enrichedMetadata.put("rubric_score", evaluation.getScore());
-                    enrichedMetadata.put("rubric_passed", evaluation.isPassed());
-                    enrichedMetadata.put("rubric_id", rubricId);
-
-                    NodeResult enrichedResult =
-                            new NodeResult(
-                                    br.getResult().getStatus(),
-                                    br.getResult().getOutput(),
-                                    enrichedMetadata);
-
-                    enriched.add(new BranchResult(br.getBranchId(), enrichedResult));
-
-                    logger.info(
-                            "Branch "
-                                    + br.getBranchId()
-                                    + " rubric '"
-                                    + rubricId
-                                    + "': score="
-                                    + evaluation.getScore()
-                                    + ", passed="
-                                    + evaluation.isPassed());
-                } catch (Exception e) {
-                    logger.warning(
-                            "Rubric evaluation failed for branch "
-                                    + br.getBranchId()
-                                    + ": "
-                                    + e.getMessage());
-                    enriched.add(br);
-                }
+            NodeResult result = br.getResult();
+            if (result.getStatus() == ResultStatus.SUCCESS && result.getOutput() != null) {
+                outputs.put(br.getBranchId(), result.getOutput());
             } else {
-                enriched.add(br);
+                allSuccess = false;
+                String msg =
+                        result.getOutput() != null
+                                ? result.getOutput().toString()
+                                : "Branch returned null output";
+                outputs.put(br.getBranchId(), new FailureMarker(msg));
             }
         }
 
-        return enriched;
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("branch_count", branchResults.size());
+
+        return new NodeResult(
+                allSuccess ? ResultStatus.SUCCESS : ResultStatus.FAILURE, outputs, metadata);
     }
 
-    /// Registers a rubric in the engine if not already present.
-    ///
-    /// Reuses the lazy-registration pattern from {@link io.hensu.core.execution.WorkflowExecutor}
-    /// to avoid redundant file parsing on retries.
-    ///
-    /// @param rubricEngine rubric engine to register with, not null
-    /// @param rubricId rubric identifier, not null
-    /// @param workflow workflow containing rubric path mappings, not null
-    private void registerRubricIfAbsent(
-            RubricEngine rubricEngine, String rubricId, Workflow workflow) {
-        if (!rubricEngine.exists(rubricId)) {
-            String rubricPath = workflow.getRubrics().get(rubricId);
-            if (rubricPath != null) {
-                Rubric rubric = RubricParser.parse(Path.of(rubricPath));
-                rubricEngine.registerRubric(rubric);
-            }
-        }
-    }
-
-    private NodeResult toNodeResult(AgentResponse response) {
-        return switch (response) {
-            case AgentResponse.TextResponse t ->
-                    new NodeResult(ResultStatus.SUCCESS, t.content(), t.metadata());
-            case AgentResponse.ToolRequest t ->
-                    new NodeResult(
-                            ResultStatus.SUCCESS,
-                            "Tool: " + t.toolName(),
-                            Map.of("toolName", t.toolName(), "arguments", t.arguments()));
-            case AgentResponse.PlanProposal p ->
-                    new NodeResult(
-                            ResultStatus.SUCCESS,
-                            "Plan with " + p.steps().size() + " steps",
-                            Map.of("steps", p.steps()));
-            case AgentResponse.Error e ->
-                    new NodeResult(
-                            ResultStatus.FAILURE,
-                            e.message(),
-                            Map.of("errorType", e.errorType().name()));
-        };
-    }
+    // -- Consensus evaluation + yields merge ------------------------------------
 
     private NodeResult evaluateConsensus(
             ConsensusConfig config,
             List<BranchResult> branchResults,
             HensuState state,
-            AgentRegistry agentRegistry)
+            AgentRegistry agentRegistry,
+            ExecutionListener listener)
             throws Exception {
 
-        // Delegate to ConsensusEvaluator for strategy-specific logic
         ConsensusResult consensusResult =
-                consensusEvaluator.evaluate(config, branchResults, state, agentRegistry);
+                consensusEvaluator.evaluate(config, branchResults, state, agentRegistry, listener);
 
-        // Store results in context for downstream processing
+        // Merge branch yields into parent context.
+        // Vote-based strategies: merge ALL yields – the vote gates the transition,
+        // not the data. Every branch's domain output flows to downstream nodes.
+        // JUDGE_DECIDES: merge only winner yields – it's a pick-the-best selection.
+        boolean judgeStrategy = config.getStrategy() == ConsensusStrategy.JUDGE_DECIDES;
+        Set<String> winnerIds =
+                judgeStrategy ? new HashSet<>(consensusResult.winningBranchIds()) : Set.of();
+
+        for (BranchResult br : branchResults) {
+            if (!judgeStrategy || winnerIds.contains(br.getBranchId())) {
+                state.getContext().putAll(br.yields());
+            }
+        }
+
+        // Store consensus metadata in context for downstream processing
         state.getContext().put("consensus_reached", consensusResult.consensusReached());
         state.getContext().put("consensus_result", consensusResult);
         state.getContext().put("consensus_votes", consensusResult.votes());
@@ -401,15 +352,17 @@ public class ParallelNodeExecutor implements NodeExecutor<ParallelNode> {
             state.getContext().put("consensus_winning_branch", consensusResult.winningBranchId());
         }
 
-        // Build metadata
+        // Build result metadata
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("consensus_reached", consensusResult.consensusReached());
         metadata.put("strategy", config.getStrategy().name());
-        metadata.put("winning_branch", consensusResult.winningBranchId());
         metadata.put("approve_count", consensusResult.approveCount());
         metadata.put("reject_count", consensusResult.rejectCount());
         metadata.put("average_score", consensusResult.averageScore());
         metadata.put("reasoning", consensusResult.reasoning());
+        if (!consensusResult.winningBranchIds().isEmpty()) {
+            metadata.put("winning_branches", consensusResult.winningBranchIds());
+        }
         metadata.put(
                 "branch_results",
                 branchResults.stream()
@@ -427,9 +380,13 @@ public class ParallelNodeExecutor implements NodeExecutor<ParallelNode> {
                         + consensusResult.rejectCount()
                         + ")");
 
+        Object output =
+                consensusResult.finalOutput() != null
+                        ? consensusResult.finalOutput()
+                        : consensusResult.reasoning();
         return new NodeResult(
                 consensusResult.consensusReached() ? ResultStatus.SUCCESS : ResultStatus.FAILURE,
-                consensusResult.finalOutput(),
+                output,
                 metadata);
     }
 }

--- a/hensu-core/src/main/java/io/hensu/core/execution/executor/StandardNodeExecutor.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/executor/StandardNodeExecutor.java
@@ -1,34 +1,15 @@
 package io.hensu.core.execution.executor;
 
-import io.hensu.core.agent.Agent;
-import io.hensu.core.agent.AgentRegistry;
-import io.hensu.core.agent.AgentResponse;
-import io.hensu.core.agent.AgentResponse.Error;
-import io.hensu.core.agent.AgentResponse.TextResponse;
-import io.hensu.core.execution.ExecutionListener;
-import io.hensu.core.execution.enricher.EngineVariablePromptEnricher;
-import io.hensu.core.execution.result.ResultStatus;
 import io.hensu.core.state.HensuState;
 import io.hensu.core.template.TemplateResolver;
 import io.hensu.core.workflow.node.StandardNode;
-import java.util.Map;
 import java.util.logging.Logger;
 
 /// Executes standard workflow nodes by invoking the configured agent.
 ///
-/// Resolves the prompt template, enriches it with engine variable format requirements
-/// (rubric criteria, score, approved) via {@link EngineVariablePromptEnricher}, then
-/// delegates to the configured agent.
-///
-/// This executor is stateless — all dependencies are obtained from
-/// {@link ExecutionContext}.
-///
-/// ### Features
-///
-/// - Resolves template variables in the prompt
-/// - Supports prompt override for backtracked execution
-/// - Injects rubric criteria and engine variable requirements before the agent call
-/// - Notifies listeners before/after agent execution
+/// Handles node-specific concerns (prompt override for backtracked execution,
+/// {@code current_node} propagation, stale writes cleanup) then delegates the
+/// agent call lifecycle to {@link AgentLifecycleRunner}.
 ///
 /// @implNote **Immutable after construction.** Stateless; safe to share across
 /// Virtual Threads.
@@ -44,53 +25,26 @@ public class StandardNodeExecutor implements NodeExecutor<StandardNode> {
     @Override
     public NodeResult execute(StandardNode node, ExecutionContext context) {
         HensuState state = context.getState();
-        ExecutionListener listener = context.getListener();
-        AgentRegistry agentRegistry = context.getAgentRegistry();
-        TemplateResolver templateResolver = context.getTemplateResolver();
 
-        Agent agent =
-                agentRegistry
-                        .getAgent(node.getAgentId())
-                        .orElseThrow(
-                                () ->
-                                        new IllegalStateException(
-                                                "Agent not found: " + node.getAgentId()));
-
+        // Node-specific: prompt override for backtracked execution
         Object promptOverride = state.getContext().remove("_prompt_override");
-        String resolvedPrompt;
-        if (promptOverride != null) {
-            resolvedPrompt = promptOverride.toString();
-        } else {
-            resolvedPrompt =
-                    node.getPrompt() != null
-                            ? templateResolver.resolve(node.getPrompt(), state.getContext())
-                            : "";
-        }
-
-        resolvedPrompt = EngineVariablePromptEnricher.DEFAULT.enrich(resolvedPrompt, node, context);
+        String prompt = promptOverride != null ? promptOverride.toString() : node.getPrompt();
 
         logger.info("Executing node: " + node.getId() + " with agent: " + node.getAgentId());
 
         // Propagate current node ID into context for agent awareness
         state.getContext().put("current_node", node.getId());
 
+        // Resolve template while writes variables are still in context
+        TemplateResolver resolver = context.getTemplateResolver();
+        String resolved = prompt != null ? resolver.resolve(prompt, state.getContext()) : "";
+
         // Remove stale output variables so they don't shadow this node's computation.
-        // Template resolution already happened above, so this is safe.
         // OutputExtractionPostProcessor will repopulate these with fresh values after execution.
         node.getWrites().forEach(state.getContext().keySet()::remove);
 
-        // Notify listener before agent execution
-        listener.onAgentStart(node.getId(), node.getAgentId(), resolvedPrompt);
-
-        AgentResponse response = agent.execute(resolvedPrompt, state.getContext());
-
-        // Notify listener after agent execution
-        listener.onAgentComplete(node.getId(), node.getAgentId(), response);
-
-        return switch (response) {
-            case TextResponse t -> new NodeResult(ResultStatus.SUCCESS, t.content(), t.metadata());
-            case Error e -> new NodeResult(ResultStatus.FAILURE, e.message(), Map.of());
-            default -> new NodeResult(ResultStatus.SUCCESS, "Response received", Map.of());
-        };
+        // Delegate to shared agent execution lifecycle (prompt already resolved)
+        return AgentLifecycleRunner.execute(
+                node.getId(), node.getAgentId(), resolved, node, context);
     }
 }

--- a/hensu-core/src/main/java/io/hensu/core/execution/parallel/Branch.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/parallel/Branch.java
@@ -1,29 +1,72 @@
 package io.hensu.core.execution.parallel;
 
+import io.hensu.core.execution.EngineVariables;
+import java.util.List;
+
 /// Represents a single execution branch within a parallel node.
 ///
 /// A branch defines one path of concurrent execution, specifying which agent
-/// executes what prompt, with optional rubric-based evaluation and weighted voting.
+/// executes what prompt, with optional rubric-based evaluation, weighted voting,
+/// and structured output declarations via {@code yields}.
 ///
 /// @param id unique identifier for this branch within the parallel node, not null
 /// @param agentId identifier of the agent to execute this branch, not null
 /// @param prompt the prompt template to send to the agent, may be null
 /// @param rubricId optional rubric identifier for evaluating branch output, may be null
 /// @param weight vote weight for weighted consensus strategies (default 1.0), positive
+/// @param yields ordered list of state variable names this branch produces, never null
 ///
 /// @see io.hensu.core.workflow.node.ParallelNode for parallel execution
 /// @see BranchResult for execution results
 /// @see ConsensusEvaluator for weighted vote calculation
-public record Branch(String id, String agentId, String prompt, String rubricId, double weight) {
+public record Branch(
+        String id,
+        String agentId,
+        String prompt,
+        String rubricId,
+        double weight,
+        List<String> yields) {
 
-    /// Creates a branch with default weight of 1.0.
+    /// Creates a branch with default weight of 1.0 and no yields.
     ///
     /// @param id unique identifier for this branch, not null
     /// @param agentId identifier of the agent to execute this branch, not null
     /// @param prompt the prompt template, may be null
     /// @param rubricId optional rubric identifier, may be null
     public Branch(String id, String agentId, String prompt, String rubricId) {
-        this(id, agentId, prompt, rubricId, 1.0);
+        this(id, agentId, prompt, rubricId, 1.0, List.of());
+    }
+
+    /// Creates a branch with specified weight and no yields.
+    ///
+    /// @param id unique identifier for this branch, not null
+    /// @param agentId identifier of the agent to execute this branch, not null
+    /// @param prompt the prompt template, may be null
+    /// @param rubricId optional rubric identifier, may be null
+    /// @param weight vote weight, positive
+    public Branch(String id, String agentId, String prompt, String rubricId, double weight) {
+        this(id, agentId, prompt, rubricId, weight, List.of());
+    }
+
+    /// Canonical constructor – defensively copies yields list and validates
+    /// that no yield name collides with reserved engine variable names.
+    ///
+    /// @throws IllegalArgumentException if any yield name is a reserved engine variable
+    public Branch {
+        yields = yields != null ? List.copyOf(yields) : List.of();
+        for (String field : yields) {
+            if (EngineVariables.isEngineVar(field)) {
+                throw new IllegalArgumentException(
+                        "Branch '"
+                                + id
+                                + "': yield field '"
+                                + field
+                                + "' is a reserved engine variable. "
+                                + "Use a different name (e.g. 'review_"
+                                + field
+                                + "').");
+            }
+        }
     }
 
     /// Returns the agent identifier for this branch.
@@ -52,5 +95,12 @@ public record Branch(String id, String agentId, String prompt, String rubricId, 
     /// @return positive weight value (default 1.0)
     public double getWeight() {
         return weight;
+    }
+
+    /// Returns the ordered list of state variable names this branch produces.
+    ///
+    /// @return immutable list of yield keys, never null (empty if no yields declared)
+    public List<String> getYields() {
+        return yields;
     }
 }

--- a/hensu-core/src/main/java/io/hensu/core/execution/parallel/BranchExecutionConfig.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/parallel/BranchExecutionConfig.java
@@ -1,0 +1,37 @@
+package io.hensu.core.execution.parallel;
+
+import java.util.List;
+
+/// Execution metadata for a parallel branch, carried on {@link
+/// io.hensu.core.execution.executor.ExecutionContext} rather than in the
+/// user-visible state context map.
+///
+/// This record exists to keep engine-internal flags out of
+/// {@code state.getContext()} – the mutable map that flows between nodes and
+/// is visible to agents. Without it, flags like "is this a consensus branch?"
+/// would pollute the user data bus and leak to the LLM.
+///
+/// @param consensusBranch true if the parent parallel node has consensus config
+/// @param consensusStrategy the consensus strategy in use, null if no consensus
+/// @param yields ordered list of yield field names declared by the branch, never null
+///
+/// @see io.hensu.core.execution.executor.ExecutionContext#getBranchConfig()
+/// @see io.hensu.core.execution.enricher.ScoreVariableInjector
+/// @see io.hensu.core.execution.enricher.ApprovalVariableInjector
+/// @see io.hensu.core.execution.enricher.RecommendationVariableInjector
+/// @see io.hensu.core.execution.enricher.YieldsVariableInjector
+public record BranchExecutionConfig(
+        boolean consensusBranch, ConsensusStrategy consensusStrategy, List<String> yields) {
+
+    /// Canonical constructor – defensively copies yields list.
+    public BranchExecutionConfig {
+        yields = yields != null ? List.copyOf(yields) : List.of();
+    }
+
+    /// Returns true if this branch needs self-scoring engine variables
+    /// (score, approved, recommendation). JUDGE_DECIDES branches do not
+    /// self-score – the judge agent makes the decision.
+    public boolean needsSelfScoring() {
+        return consensusBranch && consensusStrategy != ConsensusStrategy.JUDGE_DECIDES;
+    }
+}

--- a/hensu-core/src/main/java/io/hensu/core/execution/parallel/BranchResult.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/parallel/BranchResult.java
@@ -1,18 +1,45 @@
 package io.hensu.core.execution.parallel;
 
 import io.hensu.core.execution.executor.NodeResult;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /// Result of executing a single branch in parallel execution.
 ///
-/// Captures the outcome of one branch's agent execution, including the
-/// branch identifier for correlation with the original branch definition.
+/// Captures the outcome of one branch's agent execution together with
+/// its extracted structured output ({@code yields}) and configured vote
+/// weight. The yields map contains both domain variables declared via
+/// {@link Branch#getYields()} and engine variables ({@code score},
+/// {@code approved}, {@code recommendation}) extracted by the processor
+/// pipeline.
 ///
 /// @param branchId identifier of the branch that produced this result, not null
-/// @param result the node execution result containing status and output, not null
+/// @param result the node execution result containing status and raw output, not null
+/// @param yields extracted structured output awaiting promotion to shared state, never null
+/// @param weight vote weight copied from {@link Branch#getWeight()}, positive
 ///
 /// @see Branch for branch definition
 /// @see io.hensu.core.execution.executor.ParallelNodeExecutor for execution
-public record BranchResult(String branchId, NodeResult result) {
+public record BranchResult(
+        String branchId, NodeResult result, Map<String, Object> yields, double weight) {
+
+    /// Canonical constructor – defensively copies yields map.
+    ///
+    /// Uses {@link Collections#unmodifiableMap} rather than {@link Map#copyOf}
+    /// because extracted values may include JSON nulls.
+    @SuppressWarnings("Java9CollectionFactory")
+    public BranchResult {
+        yields = yields != null ? Collections.unmodifiableMap(new HashMap<>(yields)) : Map.of();
+    }
+
+    /// Creates a result with no yields and default weight.
+    ///
+    /// @param branchId identifier of the branch, not null
+    /// @param result the node execution result, not null
+    public BranchResult(String branchId, NodeResult result) {
+        this(branchId, result, Map.of(), 1.0);
+    }
 
     /// Returns the identifier of the branch that produced this result.
     ///
@@ -23,7 +50,7 @@ public record BranchResult(String branchId, NodeResult result) {
 
     /// Returns the execution result for this branch.
     ///
-    /// @return the node result containing status and output, not null
+    /// @return the node result containing status and raw output, not null
     public NodeResult getResult() {
         return result;
     }

--- a/hensu-core/src/main/java/io/hensu/core/execution/parallel/ConsensusEvaluator.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/parallel/ConsensusEvaluator.java
@@ -3,33 +3,32 @@ package io.hensu.core.execution.parallel;
 import io.hensu.core.agent.Agent;
 import io.hensu.core.agent.AgentRegistry;
 import io.hensu.core.agent.AgentResponse;
-import io.hensu.core.execution.executor.NodeResult;
+import io.hensu.core.execution.EngineVariables;
+import io.hensu.core.execution.ExecutionListener;
 import io.hensu.core.state.HensuState;
+import io.hensu.core.util.AgentOutputValidator;
 import io.hensu.core.util.JsonUtil;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /// Evaluates consensus from parallel branch execution results.
 ///
-/// Supports multiple consensus strategies:
-/// - **MAJORITY_VOTE**: Consensus when more than half approve
-/// - **UNANIMOUS**: Consensus only when all branches approve
-/// - **WEIGHTED_VOTE**: Weighted scoring with configurable threshold
-/// - **JUDGE_DECIDES**: External agent makes the final decision
+/// Reads structured data exclusively from {@link BranchResult#yields()} –
+/// engine variables ({@code score}, {@code approved}) are extracted by the
+/// processor pipeline, not parsed from raw text.
 ///
-/// ### Vote Extraction
-/// Votes are extracted from branch outputs by:
-/// 1. Checking metadata for explicit "score" field
-/// 2. Parsing output text for score/rating patterns
-/// 3. Looking for approval/rejection keywords
-/// 4. Falling back to neutral score (50.0) if undetermined
+/// ### Supported strategies
+/// - **MAJORITY_VOTE** – consensus when approvals strictly exceed threshold ratio
+/// - **UNANIMOUS** – consensus only when every branch approves
+/// - **WEIGHTED_VOTE** – weighted scoring with configurable threshold
+/// - **JUDGE_DECIDES** – external agent makes the final decision
 ///
-/// @implNote **Not thread-safe**. Create a new instance for each evaluation
+/// @implNote **Not thread-safe.** Create a new instance per evaluation
 /// or synchronize externally.
 ///
 /// @see ConsensusConfig for configuration options
@@ -40,8 +39,16 @@ public class ConsensusEvaluator {
     private static final double DEFAULT_THRESHOLD = 70.0;
     private static final double DEFAULT_MAJORITY_THRESHOLD = 0.5;
     private static final double DEFAULT_WEIGHTED_THRESHOLD = 0.5;
-    private static final double NEUTRAL_SCORE = 50.0;
-    private static final double REJECT_MARGIN = 20.0;
+
+    // -- Judge protocol constants (internal to consensus, not engine variables) --
+    private static final String JUDGE_DECISION = "decision";
+    private static final String JUDGE_WINNING_BRANCH = "winning_branch";
+    private static final String JUDGE_REASONING = "reasoning";
+
+    /// All judge protocol fields for bulk extraction via
+    /// {@link JsonUtil#extractOutputParams}.
+    private static final List<String> JUDGE_FIELDS =
+            List.of(JUDGE_DECISION, JUDGE_WINNING_BRANCH, JUDGE_REASONING);
 
     /// Evaluates consensus from branch results using the configured strategy.
     ///
@@ -49,6 +56,7 @@ public class ConsensusEvaluator {
     /// @param branchResults list of results from parallel branch execution, not null
     /// @param state current workflow state for context, not null
     /// @param agentRegistry registry for looking up judge agent (JUDGE_DECIDES only), not null
+    /// @param listener execution listener for agent lifecycle events, not null
     /// @return consensus evaluation result, never null
     /// @throws Exception if judge agent execution fails (JUDGE_DECIDES strategy)
     /// @throws IllegalStateException if JUDGE_DECIDES strategy lacks judge agent ID
@@ -56,10 +64,17 @@ public class ConsensusEvaluator {
             ConsensusConfig config,
             List<BranchResult> branchResults,
             HensuState state,
-            AgentRegistry agentRegistry)
+            AgentRegistry agentRegistry,
+            ExecutionListener listener)
             throws Exception {
 
         logger.info("Evaluating consensus with strategy: " + config.getStrategy());
+
+        // JUDGE_DECIDES skips vote extraction – branches don't self-score,
+        // so extractVotes() would produce garbage defaults (score=0, approved=false).
+        if (config.getStrategy() == ConsensusStrategy.JUDGE_DECIDES) {
+            return evaluateJudgeDecides(branchResults, config, state, agentRegistry, listener);
+        }
 
         Map<String, ConsensusResult.Vote> votes = extractVotes(branchResults, config);
 
@@ -67,132 +82,89 @@ public class ConsensusEvaluator {
             case MAJORITY_VOTE -> evaluateMajorityVote(votes, config);
             case UNANIMOUS -> evaluateUnanimous(votes, config);
             case WEIGHTED_VOTE -> evaluateWeightedVote(votes, config);
-            case JUDGE_DECIDES ->
-                    evaluateJudgeDecides(votes, branchResults, config, state, agentRegistry);
+            case JUDGE_DECIDES -> throw new IllegalStateException("unreachable");
         };
     }
 
-    /// Extracts votes from branch results using rubric evaluation or text heuristics.
+    /// Extracts votes from branch results using structured yields data.
     ///
-    /// ### Vote Extraction Priority
-    /// 1. **Rubric** (authoritative): If metadata contains `rubric_passed`, use rubric score
-    ///    and pass/fail status directly — `passed` maps to APPROVE, `failed` maps to REJECT
-    /// 2. **Metadata score**: Check for explicit `score` field in metadata
-    /// 3. **Text patterns**: Parse output for "score" or "rating" followed by a number
-    /// 4. **Keywords**: Detect approve/reject/abstain keywords in output text
-    /// 5. **Threshold fallback**: Compare extracted score against configured threshold
+    /// Reads {@code score} and {@code approved} directly from
+    /// {@link BranchResult#yields()}. No text heuristics, no keyword
+    /// detection, no regex parsing.
     ///
     /// @param branchResults list of branch execution results, not null
-    /// @param config consensus configuration for threshold, not null
-    /// @return map of branch ID to extracted vote, never null
+    /// @param config consensus configuration for threshold fallback, not null
+    /// @return map of branch ID to extracted vote, never null (empty if input is empty)
     public Map<String, ConsensusResult.Vote> extractVotes(
             List<BranchResult> branchResults, ConsensusConfig config) {
 
+        if (branchResults.isEmpty()) {
+            return Map.of();
+        }
+
         Map<String, ConsensusResult.Vote> votes = new HashMap<>();
-        double defaultWeight = 1.0 / branchResults.size();
 
         for (BranchResult br : branchResults) {
             String branchId = br.getBranchId();
-            NodeResult result = br.getResult();
-            String output = result.getOutput() != null ? result.getOutput().toString() : "";
-            Map<String, Object> metadata = result.getMetadata();
+            String output =
+                    br.getResult().getOutput() != null ? br.getResult().getOutput().toString() : "";
 
-            double score;
-            ConsensusResult.VoteType voteType;
-
-            if (metadata.containsKey("rubric_passed")) {
-                // Rubric evaluation is authoritative — overrides text heuristics
-                boolean rubricPassed = (Boolean) metadata.get("rubric_passed");
-                score =
-                        metadata.containsKey("rubric_score")
-                                ? ((Number) metadata.get("rubric_score")).doubleValue()
-                                : NEUTRAL_SCORE;
-                voteType =
-                        rubricPassed
-                                ? ConsensusResult.VoteType.APPROVE
-                                : ConsensusResult.VoteType.REJECT;
-            } else {
-                // Fall through to text-based heuristics
-                score = extractScore(output, metadata);
-                voteType = determineVoteType(output, score, config.getThreshold());
-            }
-
-            double weight =
-                    metadata.containsKey("weight")
-                            ? ((Number) metadata.get("weight")).doubleValue()
-                            : defaultWeight;
+            Map<String, Object> yields = br.yields();
+            double score = readScore(yields);
+            ConsensusResult.VoteType voteType =
+                    readApproval(yields, score, config.getThreshold())
+                            ? ConsensusResult.VoteType.APPROVE
+                            : ConsensusResult.VoteType.REJECT;
 
             votes.put(
                     branchId,
-                    new ConsensusResult.Vote(branchId, branchId, voteType, score, weight, output));
+                    new ConsensusResult.Vote(
+                            branchId, branchId, voteType, score, br.weight(), output));
         }
 
         return votes;
     }
 
-    /// Extracts a numerical score from output text or metadata.
+    // -- Structured yield readers ------------------------------------------------
+
+    /// Reads the numerical score from the yields map.
     ///
-    /// @param output the branch output text, not null
-    /// @param metadata the result metadata map, not null
-    /// @return extracted score, or NEUTRAL_SCORE if not found
-    private double extractScore(String output, Map<String, Object> metadata) {
-        if (metadata.containsKey("score")) {
-            Object scoreObj = metadata.get("score");
-            if (scoreObj instanceof Number) {
-                return ((Number) scoreObj).doubleValue();
-            }
-        }
-
-        Pattern scorePattern =
-                Pattern.compile(
-                        "(?:score|rating)[\":\\s]*(\\d+(?:\\.\\d+)?)", Pattern.CASE_INSENSITIVE);
-        Matcher matcher = scorePattern.matcher(output);
-        if (matcher.find()) {
-            return Double.parseDouble(matcher.group(1));
-        }
-
-        return NEUTRAL_SCORE;
+    /// @param yields extracted branch yields, not null
+    /// @return the score value, or 0.0 if absent or not a number
+    private double readScore(Map<String, Object> yields) {
+        Object value = yields.get(EngineVariables.SCORE);
+        return value instanceof Number n ? n.doubleValue() : 0.0;
     }
 
-    /// Determines vote type from output keywords or score threshold.
+    /// Reads the approval flag from the yields map.
     ///
-    /// @param output the branch output text, not null
+    /// If {@code approved} is present as a boolean, returns it directly.
+    /// Otherwise, derives approval from score vs threshold – this covers
+    /// the case where the agent produced a score but omitted the explicit
+    /// approval field.
+    ///
+    /// @param yields extracted branch yields, not null
     /// @param score the extracted score value
     /// @param threshold configured threshold, may be null (uses default)
-    /// @return the determined vote type, never null
-    private ConsensusResult.VoteType determineVoteType(
-            String output, double score, Double threshold) {
-        String lowerOutput = output.toLowerCase();
-
-        if (lowerOutput.contains("approve")
-                || lowerOutput.contains("accept")
-                || lowerOutput.contains("pass")) {
-            return ConsensusResult.VoteType.APPROVE;
+    /// @return true if the branch approves
+    private boolean readApproval(Map<String, Object> yields, double score, Double threshold) {
+        Object value = yields.get(EngineVariables.APPROVED);
+        if (value instanceof Boolean b) {
+            return b;
         }
-        if (lowerOutput.contains("reject")
-                || lowerOutput.contains("deny")
-                || lowerOutput.contains("fail")) {
-            return ConsensusResult.VoteType.REJECT;
-        }
-        if (lowerOutput.contains("abstain") || lowerOutput.contains("neutral")) {
-            return ConsensusResult.VoteType.ABSTAIN;
-        }
-
         double effectiveThreshold = threshold != null ? threshold : DEFAULT_THRESHOLD;
-        if (score >= effectiveThreshold) {
-            return ConsensusResult.VoteType.APPROVE;
-        } else if (score < effectiveThreshold - REJECT_MARGIN) {
-            return ConsensusResult.VoteType.REJECT;
-        } else {
-            return ConsensusResult.VoteType.ABSTAIN;
-        }
+        return score >= effectiveThreshold;
     }
+
+    // -- Strategy evaluators -----------------------------------------------------
 
     /// Evaluates consensus using majority vote strategy.
     ///
-    /// Consensus is reached when the number of approvals meets or exceeds
-    /// the threshold percentage of total votes. Defaults to 50% when no
-    /// threshold is configured.
+    /// Consensus is reached when the number of approvals **strictly exceeds**
+    /// the threshold ratio of total votes. At 50% threshold, 2/4 does NOT pass.
+    ///
+    /// Vote-based strategies do not compute winners – the vote gates the
+    /// transition path, ALL branch yields merge regardless of individual vote.
     ///
     /// @param votes map of branch votes, not null
     /// @param config consensus configuration with optional threshold, not null
@@ -206,36 +178,22 @@ public class ConsensusEvaluator {
 
         double effectiveThreshold =
                 config.getThreshold() != null ? config.getThreshold() : DEFAULT_MAJORITY_THRESHOLD;
-        long requiredApprovals = (long) Math.ceil(total * effectiveThreshold);
-        boolean consensusReached = approveCount >= requiredApprovals;
-
-        ConsensusResult.Vote winningVote =
-                votes.values().stream()
-                        .filter(
-                                v ->
-                                        v.voteType()
-                                                == (consensusReached
-                                                        ? ConsensusResult.VoteType.APPROVE
-                                                        : ConsensusResult.VoteType.REJECT))
-                        .max(Comparator.comparingDouble(ConsensusResult.Vote::score))
-                        .orElse(null);
+        boolean consensusReached = approveCount > (long) (total * effectiveThreshold);
 
         String reasoning =
                 String.format(
                         "Majority vote: %d approve, %d reject out of %d total"
-                                + " (threshold=%.0f%%, required=%d). %s",
+                                + " (threshold=%.0f%%, required>%d). %s",
                         approveCount,
                         rejectCount,
                         total,
                         effectiveThreshold * 100,
-                        requiredApprovals,
+                        (long) (total * effectiveThreshold),
                         consensusReached ? "Consensus reached." : "Consensus not reached.");
 
         return ConsensusResult.builder()
                 .consensusReached(consensusReached)
                 .strategyUsed(config.getStrategy())
-                .winningBranchId(winningVote != null ? winningVote.branchId() : null)
-                .finalOutput(winningVote != null ? winningVote.output() : "No consensus")
                 .votes(votes)
                 .reasoning(reasoning)
                 .build();
@@ -243,46 +201,43 @@ public class ConsensusEvaluator {
 
     /// Evaluates consensus using unanimous vote strategy.
     ///
+    /// Consensus is reached only when every branch approves. Returns
+    /// {@code consensusReached = false} for empty vote maps since
+    /// {@link java.util.stream.Stream#allMatch} returns true on empty streams.
+    ///
     /// @param votes map of branch votes, not null
     /// @param config consensus configuration, not null
     /// @return consensus result, never null
     private ConsensusResult evaluateUnanimous(
             Map<String, ConsensusResult.Vote> votes, ConsensusConfig config) {
 
-        boolean allApprove = votes.values().stream().allMatch(ConsensusResult.Vote::isApprove);
-        boolean anyReject = votes.values().stream().anyMatch(ConsensusResult.Vote::isReject);
-
-        ConsensusResult.Vote highestVote =
-                votes.values().stream()
-                        .max(Comparator.comparingDouble(ConsensusResult.Vote::score))
-                        .orElse(null);
+        boolean allApprove =
+                !votes.isEmpty()
+                        && votes.values().stream().allMatch(ConsensusResult.Vote::isApprove);
 
         String reasoning;
-        if (allApprove) {
+        if (votes.isEmpty()) {
+            reasoning = "Unanimous not reached: no branches to evaluate.";
+        } else if (allApprove) {
             reasoning = "Unanimous approval: all " + votes.size() + " branches approved.";
-        } else if (anyReject) {
+        } else {
             long rejectCount =
                     votes.values().stream().filter(ConsensusResult.Vote::isReject).count();
             reasoning =
                     String.format("Unanimous not reached: %d branch(es) rejected.", rejectCount);
-        } else {
-            reasoning = "Unanimous not reached: some branches abstained.";
         }
 
         return ConsensusResult.builder()
                 .consensusReached(allApprove)
                 .strategyUsed(config.getStrategy())
-                .winningBranchId(highestVote != null ? highestVote.branchId() : null)
-                .finalOutput(
-                        allApprove && highestVote != null
-                                ? highestVote.output()
-                                : "No unanimous consensus")
                 .votes(votes)
                 .reasoning(reasoning)
                 .build();
     }
 
     /// Evaluates consensus using weighted vote strategy.
+    ///
+    /// Weighted approve ratio must meet or exceed the threshold.
     ///
     /// @param votes map of branch votes, not null
     /// @param config consensus configuration, not null
@@ -304,17 +259,10 @@ public class ConsensusEvaluator {
 
         double threshold =
                 config.getThreshold() != null ? config.getThreshold() : DEFAULT_WEIGHTED_THRESHOLD;
-        double approveRatio =
-                (weightedApprove + weightedReject) > 0
-                        ? weightedApprove / (weightedApprove + weightedReject)
-                        : 0;
+        double totalWeighted = weightedApprove + weightedReject;
+        double approveRatio = totalWeighted > 0 ? weightedApprove / totalWeighted : 0;
 
         boolean consensusReached = approveRatio >= threshold;
-
-        ConsensusResult.Vote winningVote =
-                votes.values().stream()
-                        .max(Comparator.comparingDouble(v -> v.score() * v.weight()))
-                        .orElse(null);
 
         String reasoning =
                 String.format(
@@ -328,8 +276,6 @@ public class ConsensusEvaluator {
         return ConsensusResult.builder()
                 .consensusReached(consensusReached)
                 .strategyUsed(config.getStrategy())
-                .winningBranchId(winningVote != null ? winningVote.branchId() : null)
-                .finalOutput(winningVote != null ? winningVote.output() : "No consensus")
                 .votes(votes)
                 .reasoning(reasoning)
                 .build();
@@ -337,19 +283,25 @@ public class ConsensusEvaluator {
 
     /// Evaluates consensus by invoking a judge agent.
     ///
-    /// @param votes map of branch votes, not null
+    /// Unlike vote-based strategies, JUDGE_DECIDES skips {@link #extractVotes} entirely –
+    /// branches don't self-score, so the judge sees only branch outputs and IDs.
+    ///
+    /// Fires {@link ExecutionListener#onAgentStart} and {@link ExecutionListener#onAgentComplete}
+    /// so the judge call is visible in CLI verbose output and observability.
+    ///
     /// @param branchResults original branch results for judge context, not null
     /// @param config consensus configuration with judge agent ID, not null
     /// @param state workflow state for agent context, not null
     /// @param agentRegistry registry for looking up judge agent, not null
+    /// @param listener execution listener for agent lifecycle events, not null
     /// @return consensus result based on judge decision, never null
     /// @throws IllegalStateException if judge agent ID is missing or agent not found
     private ConsensusResult evaluateJudgeDecides(
-            Map<String, ConsensusResult.Vote> votes,
             List<BranchResult> branchResults,
             ConsensusConfig config,
             HensuState state,
-            AgentRegistry agentRegistry) {
+            AgentRegistry agentRegistry,
+            ExecutionListener listener) {
 
         String judgeAgentId = config.getJudgeAgentId();
         if (judgeAgentId == null || judgeAgentId.isBlank()) {
@@ -364,10 +316,14 @@ public class ConsensusEvaluator {
                                         new IllegalStateException(
                                                 "Judge agent not found: " + judgeAgentId));
 
-        String prompt = buildJudgePrompt(votes, branchResults);
+        Set<String> validBranchIds =
+                branchResults.stream().map(BranchResult::getBranchId).collect(Collectors.toSet());
+        String prompt = buildJudgePrompt(branchResults, validBranchIds);
 
         logger.info("Invoking judge agent: " + judgeAgentId);
+        listener.onAgentStart("consensus/judge", judgeAgentId, prompt);
         AgentResponse judgeResponse = judgeAgent.execute(prompt, state.getContext());
+        listener.onAgentComplete("consensus/judge", judgeAgentId, judgeResponse);
 
         String responseContent =
                 switch (judgeResponse) {
@@ -378,42 +334,55 @@ public class ConsensusEvaluator {
                             throw new IllegalStateException(
                                     "Unexpected response type from judge agent");
                 };
-        return parseJudgeResponse(responseContent, votes, config);
+
+        Optional<String> violation = AgentOutputValidator.validate(responseContent);
+        if (violation.isPresent()) {
+            throw new IllegalStateException("Judge agent output " + violation.get());
+        }
+
+        return parseJudgeResponse(responseContent, config, validBranchIds);
     }
 
     /// Builds the prompt for the judge agent.
     ///
-    /// @param votes map of branch votes, not null
+    /// The judge is asked only to decide (approve/reject), pick a winner, and
+    /// explain. It does NOT produce a {@code final_output} – the winning
+    /// branch's yields serve as the domain output.
+    ///
     /// @param branchResults original branch results, not null
+    /// @param validBranchIds set of valid branch IDs the judge may select, not null
     /// @return formatted judge prompt, never null
-    private String buildJudgePrompt(
-            Map<String, ConsensusResult.Vote> votes, List<BranchResult> branchResults) {
+    private String buildJudgePrompt(List<BranchResult> branchResults, Set<String> validBranchIds) {
+
         StringBuilder sb = new StringBuilder();
         sb.append(
-                "You are the judge for a consensus decision. Review the following branch results and make a final decision.\n\n");
+                """
+                You are the judge for a consensus decision. \
+                Review the following branch results and make a final decision.
+
+                """);
         sb.append("## Branch Results:\n\n");
 
         for (BranchResult br : branchResults) {
-            ConsensusResult.Vote vote = votes.get(br.getBranchId());
             sb.append(String.format("### Branch: %s\n", br.getBranchId()));
-            sb.append(String.format("Vote: %s (Score: %.1f)\n", vote.voteType(), vote.score()));
             sb.append("Output:\n```\n");
             sb.append(br.getResult().getOutput());
             sb.append("\n```\n\n");
         }
 
+        sb.append("## Valid branch IDs: ").append(validBranchIds).append("\n\n");
+
         sb.append(
                 """
                 ## Your Task:
                 1. Analyze all branch outputs
-                2. Determine if consensus should be reached
-                3. Select the best output or synthesize a final decision
+                2. Determine if the overall result should be approved or rejected
+                3. Select the winning branch
 
-                Respond with a JSON object containing:
-                - "decision": "approve" or "reject"
-                - "winning_branch": the branch ID with the best output (or null if synthesizing)
+                Respond with a JSON object containing ONLY these fields:
+                - "decision": true if approved, false if rejected
+                - "winning_branch": one of the valid branch IDs listed above
                 - "reasoning": brief explanation of your decision
-                - "final_output": the final output to use
                 """);
 
         return sb.toString();
@@ -421,30 +390,45 @@ public class ConsensusEvaluator {
 
     /// Parses the judge agent's response into a ConsensusResult.
     ///
-    /// @param judgeOutput the judge's response text, not null
-    /// @param votes original votes for inclusion in result, not null
+    /// Uses {@link JsonUtil#extractOutputParams} – the same extraction path as
+    /// {@link io.hensu.core.execution.pipeline.OutputExtractionPostProcessor}.
+    /// Validates that the judge's {@code winning_branch} is one of the actual
+    /// branch IDs to prevent ghost-winner bugs.
+    ///
+    /// @param judgeOutput the judge's response text (already validated), not null
     /// @param config consensus configuration, not null
+    /// @param validBranchIds set of actual branch IDs, not null
     /// @return parsed consensus result, never null
     private ConsensusResult parseJudgeResponse(
-            String judgeOutput, Map<String, ConsensusResult.Vote> votes, ConsensusConfig config) {
+            String judgeOutput, ConsensusConfig config, Set<String> validBranchIds) {
 
-        boolean consensusReached =
-                judgeOutput.toLowerCase().contains("\"decision\"")
-                        ? judgeOutput.toLowerCase().contains("\"approve\"")
-                        : !judgeOutput.toLowerCase().contains("reject");
+        Map<String, Object> fields = new HashMap<>();
+        JsonUtil.extractOutputParams(JUDGE_FIELDS, judgeOutput, fields, logger);
 
-        String winningBranch = JsonUtil.extractJsonField(judgeOutput, "winning_branch");
-        String reasoning = JsonUtil.extractJsonField(judgeOutput, "reasoning");
-        if (reasoning == null) {
-            reasoning = "Judge decision: " + (consensusReached ? "approved" : "rejected");
+        boolean consensusReached = fields.get(JUDGE_DECISION) instanceof Boolean b && b;
+
+        String winningBranch = fields.get(JUDGE_WINNING_BRANCH) instanceof String s ? s : null;
+
+        if (winningBranch != null && !validBranchIds.contains(winningBranch)) {
+            logger.warning(
+                    "Judge returned unknown winning_branch '"
+                            + winningBranch
+                            + "', valid IDs: "
+                            + validBranchIds);
+            winningBranch = null;
         }
+
+        String reasoning =
+                fields.get(JUDGE_REASONING) instanceof String s
+                        ? s
+                        : "Judge decision: " + (consensusReached ? "approved" : "rejected");
 
         return ConsensusResult.builder()
                 .consensusReached(consensusReached)
                 .strategyUsed(config.getStrategy())
                 .winningBranchId(winningBranch)
                 .finalOutput(judgeOutput)
-                .votes(votes)
+                .votes(Map.of())
                 .reasoning(reasoning)
                 .build();
     }

--- a/hensu-core/src/main/java/io/hensu/core/execution/parallel/ConsensusResult.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/parallel/ConsensusResult.java
@@ -1,6 +1,8 @@
 package io.hensu.core.execution.parallel;
 
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 
 /// Result of consensus evaluation across parallel branch executions.
@@ -10,7 +12,7 @@ import java.util.Map;
 ///
 /// @param consensusReached true if consensus was achieved according to the strategy
 /// @param strategyUsed the strategy that was applied, not null
-/// @param winningBranchId identifier of the branch with the winning output, may be null
+/// @param winningBranchIds identifiers of branches that won consensus, empty list if none
 /// @param finalOutput the selected output to use as the result, may be null
 /// @param votes map of branch ID to vote details, not null
 /// @param reasoning human-readable explanation of the consensus decision, may be null
@@ -20,7 +22,7 @@ import java.util.Map;
 public record ConsensusResult(
         boolean consensusReached,
         ConsensusStrategy strategyUsed,
-        String winningBranchId,
+        List<String> winningBranchIds,
         Object finalOutput,
         Map<String, Vote> votes,
         String reasoning) {
@@ -71,6 +73,15 @@ public record ConsensusResult(
         REJECT,
         /// Branch abstains from voting
         ABSTAIN
+    }
+
+    /// Returns the first winning branch identifier, or null if none.
+    ///
+    /// Convenience accessor for callers that expect a single winner.
+    ///
+    /// @return the first winning branch ID, or null if no winners
+    public String winningBranchId() {
+        return winningBranchIds.isEmpty() ? null : winningBranchIds.getFirst();
     }
 
     /// Counts the number of approval votes.
@@ -132,7 +143,7 @@ public record ConsensusResult(
     public static final class Builder {
         private boolean consensusReached;
         private ConsensusStrategy strategyUsed;
-        private String winningBranchId;
+        private final List<String> winningBranchIds = new ArrayList<>();
         private Object finalOutput;
         private Map<String, Vote> votes = Map.of();
         private String reasoning;
@@ -155,12 +166,24 @@ public record ConsensusResult(
             return this;
         }
 
-        /// Sets the winning branch identifier.
+        /// Adds a single winning branch identifier.
         ///
-        /// @param branchId the winning branch ID, may be null
+        /// @param branchId the winning branch ID, not null
         /// @return this builder for chaining
         public Builder winningBranchId(String branchId) {
-            this.winningBranchId = branchId;
+            if (branchId != null) {
+                this.winningBranchIds.add(branchId);
+            }
+            return this;
+        }
+
+        /// Sets all winning branch identifiers, replacing any previously added.
+        ///
+        /// @param branchIds the winning branch IDs, not null
+        /// @return this builder for chaining
+        public Builder winningBranchIds(List<String> branchIds) {
+            this.winningBranchIds.clear();
+            this.winningBranchIds.addAll(branchIds);
             return this;
         }
 
@@ -196,7 +219,12 @@ public record ConsensusResult(
         /// @return a new ConsensusResult, never null
         public ConsensusResult build() {
             return new ConsensusResult(
-                    consensusReached, strategyUsed, winningBranchId, finalOutput, votes, reasoning);
+                    consensusReached,
+                    strategyUsed,
+                    List.copyOf(winningBranchIds),
+                    finalOutput,
+                    votes,
+                    reasoning);
         }
     }
 }

--- a/hensu-core/src/main/java/io/hensu/core/execution/pipeline/OutputExtractionPostProcessor.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/pipeline/OutputExtractionPostProcessor.java
@@ -1,5 +1,6 @@
 package io.hensu.core.execution.pipeline;
 
+import io.hensu.core.execution.EngineVariables;
 import io.hensu.core.execution.result.ExecutionResult;
 import io.hensu.core.state.HensuState;
 import io.hensu.core.util.AgentOutputValidator;
@@ -66,17 +67,9 @@ public final class OutputExtractionPostProcessor implements PostNodeExecutionPro
 
         String output = result.getOutput().toString();
 
-        if (AgentOutputValidator.containsDangerousChars(output)) {
-            return rejectOutput(state, node.getId(), "contains illegal control characters");
-        }
-
-        if (AgentOutputValidator.containsUnicodeTricks(output)) {
-            return rejectOutput(state, node.getId(), "contains Unicode manipulation characters");
-        }
-
-        if (AgentOutputValidator.exceedsSizeLimit(
-                output, AgentOutputValidator.MAX_LLM_OUTPUT_BYTES)) {
-            return rejectOutput(state, node.getId(), "exceeds maximum allowed size");
+        Optional<String> violation = AgentOutputValidator.validate(output);
+        if (violation.isPresent()) {
+            return rejectOutput(state, node.getId(), violation.get());
         }
 
         if (node instanceof StandardNode standardNode) {
@@ -122,14 +115,14 @@ public final class OutputExtractionPostProcessor implements PostNodeExecutionPro
         boolean hasApproval = false;
         for (var rule : node.getTransitionRules()) {
             if (rule instanceof ScoreTransition) {
-                vars.add("score");
+                vars.add(EngineVariables.SCORE);
                 hasScore = true;
             } else if (rule instanceof ApprovalTransition) {
-                vars.add("approved");
+                vars.add(EngineVariables.APPROVED);
                 hasApproval = true;
             }
         }
-        if (hasScore || hasApproval) vars.add("recommendation");
+        if (hasScore || hasApproval) vars.add(EngineVariables.RECOMMENDATION);
         return vars;
     }
 

--- a/hensu-core/src/main/java/io/hensu/core/rubric/evaluator/ScoreExtractingEvaluator.java
+++ b/hensu-core/src/main/java/io/hensu/core/rubric/evaluator/ScoreExtractingEvaluator.java
@@ -1,5 +1,6 @@
 package io.hensu.core.rubric.evaluator;
 
+import io.hensu.core.execution.EngineVariables;
 import io.hensu.core.execution.executor.NodeResult;
 import io.hensu.core.rubric.model.Criterion;
 import java.util.ArrayList;
@@ -48,7 +49,7 @@ public final class ScoreExtractingEvaluator implements RubricEvaluator {
             return 0.0;
         }
 
-        Object raw = context.get("score");
+        Object raw = context.get(EngineVariables.SCORE);
         Double score = parseNumber(raw);
 
         if (score == null) {
@@ -61,7 +62,7 @@ public final class ScoreExtractingEvaluator implements RubricEvaluator {
         }
 
         if (score < criterion.getMinScore()) {
-            Object recommendation = context.get("recommendation");
+            Object recommendation = context.get(EngineVariables.RECOMMENDATION);
             if (recommendation instanceof String text && !text.isBlank()) {
                 addRecommendation(context, criterion.getId(), text);
             }

--- a/hensu-core/src/main/java/io/hensu/core/util/AgentOutputValidator.java
+++ b/hensu-core/src/main/java/io/hensu/core/util/AgentOutputValidator.java
@@ -1,6 +1,7 @@
 package io.hensu.core.util;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 /// Validates LLM-generated node output before it is stored in workflow state.
@@ -55,6 +56,26 @@ public final class AgentOutputValidator {
 
     private AgentOutputValidator() {}
 
+    /// Validates LLM output against all safety checks.
+    ///
+    /// Runs dangerous-chars, Unicode-tricks, and size-limit checks in sequence.
+    /// Returns empty if the output is safe; the rejection reason if any check fails.
+    ///
+    /// @param value the output string to validate, may be null
+    /// @return empty if valid or null; the failure reason otherwise
+    public static Optional<String> validate(String value) {
+        if (containsDangerousChars(value)) {
+            return Optional.of("contains illegal control characters");
+        }
+        if (containsUnicodeTricks(value)) {
+            return Optional.of("contains Unicode manipulation characters");
+        }
+        if (exceedsSizeLimit(value, MAX_LLM_OUTPUT_BYTES)) {
+            return Optional.of("exceeds maximum allowed size");
+        }
+        return Optional.empty();
+    }
+
     /// Checks whether the value contains dangerous ASCII control characters.
     ///
     /// Detects null bytes and non-printable control characters
@@ -64,7 +85,7 @@ public final class AgentOutputValidator {
     /// @param value the string to check, may be null
     /// @return `true` if the value contains illegal control characters;
     ///         `false` if null or clean
-    public static boolean containsDangerousChars(String value) {
+    static boolean containsDangerousChars(String value) {
         return value != null && DANGEROUS_CONTROL.matcher(value).find();
     }
 
@@ -77,7 +98,7 @@ public final class AgentOutputValidator {
     /// @param value the string to check, may be null
     /// @return `true` if the value contains Unicode manipulation characters;
     ///         `false` if null or clean
-    public static boolean containsUnicodeTricks(String value) {
+    static boolean containsUnicodeTricks(String value) {
         return value != null && UNICODE_TRICKS.matcher(value).find();
     }
 
@@ -87,7 +108,7 @@ public final class AgentOutputValidator {
     /// @param maxBytes the maximum allowed size in bytes, must be positive
     /// @return `true` if the UTF-8 byte length of `value` exceeds `maxBytes`;
     ///         `false` if null or within limit
-    public static boolean exceedsSizeLimit(String value, int maxBytes) {
+    static boolean exceedsSizeLimit(String value, int maxBytes) {
         return value != null && value.getBytes(StandardCharsets.UTF_8).length > maxBytes;
     }
 }

--- a/hensu-core/src/main/java/io/hensu/core/workflow/state/WorkflowStateSchema.java
+++ b/hensu-core/src/main/java/io/hensu/core/workflow/state/WorkflowStateSchema.java
@@ -1,5 +1,6 @@
 package io.hensu.core.workflow.state;
 
+import io.hensu.core.execution.EngineVariables;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -43,7 +44,7 @@ public final class WorkflowStateSchema {
     /// - `recommendation` — plain-string improvement feedback or review reasoning, injected
     ///                      automatically on any node with `onScore` or `onApproval` routing
     public static final Set<String> ENGINE_VARIABLES =
-            Set.of("score", "approved", "recommendation");
+            Set.of(EngineVariables.SCORE, EngineVariables.APPROVED, EngineVariables.RECOMMENDATION);
 
     private final List<StateVariableDeclaration> variables;
     private final Map<String, StateVariableDeclaration> index;

--- a/hensu-core/src/main/java/io/hensu/core/workflow/transition/ApprovalTransition.java
+++ b/hensu-core/src/main/java/io/hensu/core/workflow/transition/ApprovalTransition.java
@@ -1,5 +1,6 @@
 package io.hensu.core.workflow.transition;
 
+import io.hensu.core.execution.EngineVariables;
 import io.hensu.core.execution.executor.NodeResult;
 import io.hensu.core.state.HensuState;
 import java.util.Map;
@@ -41,7 +42,7 @@ public record ApprovalTransition(boolean expected, String targetNode) implements
             return null;
         }
 
-        Boolean parsed = parseBoolean(context.get("approved"));
+        Boolean parsed = parseBoolean(context.get(EngineVariables.APPROVED));
         if (parsed == null) {
             return null;
         }

--- a/hensu-core/src/main/java/io/hensu/core/workflow/transition/ScoreTransition.java
+++ b/hensu-core/src/main/java/io/hensu/core/workflow/transition/ScoreTransition.java
@@ -1,5 +1,6 @@
 package io.hensu.core.workflow.transition;
 
+import io.hensu.core.execution.EngineVariables;
 import io.hensu.core.execution.executor.NodeResult;
 import io.hensu.core.rubric.model.ScoreCondition;
 import io.hensu.core.state.HensuState;
@@ -39,7 +40,7 @@ public record ScoreTransition(List<ScoreCondition> conditions) implements Transi
     private Double extractScore(HensuState state) {
         Map<String, Object> context = state.getContext();
         if (context == null) return null;
-        return parseScore(context.get("score"));
+        return parseScore(context.get(EngineVariables.SCORE));
     }
 
     private Double parseScore(Object value) {

--- a/hensu-core/src/test/java/io/hensu/core/execution/WorkflowExecutorParallelTest.java
+++ b/hensu-core/src/test/java/io/hensu/core/execution/WorkflowExecutorParallelTest.java
@@ -2,18 +2,16 @@ package io.hensu.core.execution;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.hensu.core.agent.Agent;
 import io.hensu.core.agent.AgentConfig;
 import io.hensu.core.agent.AgentResponse;
+import io.hensu.core.execution.parallel.Branch;
 import io.hensu.core.execution.parallel.ConsensusStrategy;
 import io.hensu.core.execution.result.ExecutionResult;
 import io.hensu.core.execution.result.ExitStatus;
-import io.hensu.core.rubric.RubricNotFoundException;
-import io.hensu.core.rubric.evaluator.RubricEvaluation;
 import io.hensu.core.workflow.Workflow;
 import io.hensu.core.workflow.node.Node;
 import io.hensu.core.workflow.node.ParallelNode;
@@ -31,7 +29,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class WorkflowExecutorParallelTest extends WorkflowExecutorTestBase {
 
-    // — Majority vote ————————————————————————————————————————————————————
+    // — Structured consensus pipeline ————————————————————————————————————
 
     @ParameterizedTest
     @MethodSource("majorityConsensusCases")
@@ -55,60 +53,66 @@ class WorkflowExecutorParallelTest extends WorkflowExecutorTestBase {
 
     static Stream<Arguments> majorityConsensusCases() {
         return Stream.of(
-                // 2 approve / 1 reject → majority approves → SUCCESS
+                // 2 approve / 1 reject → majority (2 > 1.5) → SUCCESS
                 Arguments.of(
-                        "I approve this work. Score: 90",
-                        "I approve. Score: 85",
-                        "I reject this. Score: 30",
+                        """
+                        {"score": 90, "approved": true, "recommendation": "Good"}""",
+                        """
+                        {"score": 85, "approved": true, "recommendation": "Solid"}""",
+                        """
+                        {"score": 30, "approved": false, "recommendation": "Needs work"}""",
                         ExitStatus.SUCCESS),
                 // 1 approve / 2 reject → majority rejects → FAILURE
                 Arguments.of(
-                        "I approve. Score: 90",
-                        "I reject this. Score: 20",
-                        "I reject this. Score: 15",
+                        """
+                        {"score": 90, "approved": true, "recommendation": "Good"}""",
+                        """
+                        {"score": 20, "approved": false, "recommendation": "Bad"}""",
+                        """
+                        {"score": 15, "approved": false, "recommendation": "Bad"}""",
                         ExitStatus.FAILURE));
     }
 
-    // — No-consensus collection ——————————————————————————————————————————
+    // — Yields merge: the core new feature ———————————————————————————————
 
     @Test
-    void shouldCollectBranchOutputsWithoutConsensus() throws Exception {
-        // No consensus config → all branch outputs collected → always SUCCESS.
+    void shouldMergeWinnerYieldsIntoContext() throws Exception {
+        // Both branches approve (unanimous) and yield "api_schema".
+        // After consensus, the winning branch's extracted api_schema must be in context.
         var agent1 = mock(Agent.class);
         var agent2 = mock(Agent.class);
-        when(agentRegistry.getAgent("writer1")).thenReturn(Optional.of(agent1));
-        when(agentRegistry.getAgent("writer2")).thenReturn(Optional.of(agent2));
+        when(agentRegistry.getAgent("a1")).thenReturn(Optional.of(agent1));
+        when(agentRegistry.getAgent("a2")).thenReturn(Optional.of(agent2));
         when(agent1.execute(any(), any()))
-                .thenReturn(AgentResponse.TextResponse.of("Draft from writer 1"));
+                .thenReturn(
+                        AgentResponse.TextResponse.of(
+                                """
+                {"score": 90, "approved": true, "recommendation": "Good",\
+                 "api_schema": "openapi: 3.0"}"""));
         when(agent2.execute(any(), any()))
-                .thenReturn(AgentResponse.TextResponse.of("Draft from writer 2"));
+                .thenReturn(
+                        AgentResponse.TextResponse.of(
+                                """
+                {"score": 85, "approved": true, "recommendation": "Solid",\
+                 "api_schema": "openapi: 3.1"}"""));
 
         var agents =
                 Map.of(
-                        "writer1",
-                                AgentConfig.builder()
-                                        .id("writer1")
-                                        .role("Writer")
-                                        .model("test")
-                                        .build(),
-                        "writer2",
-                                AgentConfig.builder()
-                                        .id("writer2")
-                                        .role("Writer")
-                                        .model("test")
-                                        .build());
+                        "a1", AgentConfig.builder().id("a1").role("Agent").model("test").build(),
+                        "a2", AgentConfig.builder().id("a2").role("Agent").model("test").build());
         var nodes = new HashMap<String, Node>();
         nodes.put(
                 "parallel",
                 ParallelNode.builder("parallel")
-                        .branch("b1", "writer1", "Write draft")
-                        .branch("b2", "writer2", "Write draft")
+                        .branch(new Branch("b1", "a1", "Analyze", null, 1.0, List.of("api_schema")))
+                        .branch(new Branch("b2", "a2", "Review", null, 1.0, List.of("api_schema")))
+                        .consensus(null, ConsensusStrategy.UNANIMOUS)
                         .transitionRules(List.of(new SuccessTransition("end")))
                         .build());
         nodes.put("end", end("end"));
         var workflow =
                 Workflow.builder()
-                        .id("no-consensus")
+                        .id("yields-merge")
                         .agents(agents)
                         .nodes(nodes)
                         .startNode("parallel")
@@ -116,242 +120,152 @@ class WorkflowExecutorParallelTest extends WorkflowExecutorTestBase {
 
         var result = executor.execute(workflow, new HashMap<>());
 
-        assertThat(result).isInstanceOf(ExecutionResult.Completed.class);
-        assertThat(((ExecutionResult.Completed) result).getExitStatus())
-                .isEqualTo(ExitStatus.SUCCESS);
+        var completed = (ExecutionResult.Completed) result;
+        assertThat(completed.getExitStatus()).isEqualTo(ExitStatus.SUCCESS);
+        assertThat(completed.getFinalState().getContext()).containsKey("api_schema");
+        assertThat(completed.getFinalState().getContext().get("api_schema").toString())
+                .startsWith("openapi:");
     }
 
-    // — Rubric-based branch evaluation ———————————————————————————————————
-
     @Test
-    void shouldEvaluateBranchRubricInConsensus() throws Exception {
-        // 3 branches with rubricId; r1/r2 pass (90/85), r3 fails (40).
-        // 2/3 pass → MAJORITY_VOTE → consensus reached → SUCCESS.
+    void shouldMergeAllBranchYieldsForVoteStrategies() throws Exception {
+        // b1+b3 approve → consensus reached, b2 rejects.
+        // Vote strategies merge ALL yields – the vote gates the transition,
+        // not the data. Every branch's domain output flows to downstream nodes.
+        // 3 branches needed: majority requires >50% (strict), so 2/3 > 1.5 passes.
         var agent1 = mock(Agent.class);
         var agent2 = mock(Agent.class);
         var agent3 = mock(Agent.class);
-        when(agentRegistry.getAgent("r1")).thenReturn(Optional.of(agent1));
-        when(agentRegistry.getAgent("r2")).thenReturn(Optional.of(agent2));
-        when(agentRegistry.getAgent("r3")).thenReturn(Optional.of(agent3));
-        when(agent1.execute(any(), any())).thenReturn(AgentResponse.TextResponse.of("Good output"));
+        when(agentRegistry.getAgent("a1")).thenReturn(Optional.of(agent1));
+        when(agentRegistry.getAgent("a2")).thenReturn(Optional.of(agent2));
+        when(agentRegistry.getAgent("a3")).thenReturn(Optional.of(agent3));
+        when(agent1.execute(any(), any()))
+                .thenReturn(
+                        AgentResponse.TextResponse.of(
+                                """
+                {"score": 90, "approved": true, "recommendation": "Good",\
+                 "winner_data": "from-b1"}"""));
         when(agent2.execute(any(), any()))
-                .thenReturn(AgentResponse.TextResponse.of("Great output"));
-        when(agent3.execute(any(), any())).thenReturn(AgentResponse.TextResponse.of("Poor output"));
-        when(rubricEngine.exists("quality")).thenReturn(true);
-        when(rubricEngine.evaluate(eq("quality"), any(), any()))
                 .thenReturn(
-                        RubricEvaluation.builder()
-                                .rubricId("quality")
-                                .score(90.0)
-                                .passed(true)
-                                .build())
+                        AgentResponse.TextResponse.of(
+                                """
+                {"score": 20, "approved": false, "recommendation": "Bad",\
+                 "loser_data": "from-b2"}"""));
+        when(agent3.execute(any(), any()))
                 .thenReturn(
-                        RubricEvaluation.builder()
-                                .rubricId("quality")
-                                .score(85.0)
-                                .passed(true)
-                                .build())
-                .thenReturn(
-                        RubricEvaluation.builder()
-                                .rubricId("quality")
-                                .score(40.0)
-                                .passed(false)
-                                .build());
+                        AgentResponse.TextResponse.of(
+                                """
+                {"score": 80, "approved": true, "recommendation": "Solid"}"""));
 
         var agents =
                 Map.of(
-                        "r1",
-                        AgentConfig.builder().id("r1").role("Reviewer").model("test").build(),
-                        "r2",
-                        AgentConfig.builder().id("r2").role("Reviewer").model("test").build(),
-                        "r3",
-                        AgentConfig.builder().id("r3").role("Reviewer").model("test").build());
+                        "a1", AgentConfig.builder().id("a1").role("Agent").model("test").build(),
+                        "a2", AgentConfig.builder().id("a2").role("Agent").model("test").build(),
+                        "a3", AgentConfig.builder().id("a3").role("Agent").model("test").build());
         var nodes = new HashMap<String, Node>();
         nodes.put(
                 "parallel",
                 ParallelNode.builder("parallel")
-                        .branch("b1", "r1", "Review", "quality")
-                        .branch("b2", "r2", "Review", "quality")
-                        .branch("b3", "r3", "Review", "quality")
+                        .branch(new Branch("b1", "a1", "Work", null, 1.0, List.of("winner_data")))
+                        .branch(new Branch("b2", "a2", "Work", null, 1.0, List.of("loser_data")))
+                        .branch(new Branch("b3", "a3", "Work", null, 1.0, List.of()))
                         .consensus(null, ConsensusStrategy.MAJORITY_VOTE)
                         .transitionRules(
                                 List.of(
-                                        new SuccessTransition("success-end"),
-                                        new FailureTransition(0, "failure-end")))
+                                        new SuccessTransition("end"),
+                                        new FailureTransition(0, "fail-end")))
                         .build());
-        nodes.put("success-end", end("success-end"));
-        nodes.put("failure-end", failEnd("failure-end"));
+        nodes.put("end", end("end"));
+        nodes.put("fail-end", failEnd("fail-end"));
         var workflow =
                 Workflow.builder()
-                        .id("rubric-consensus")
+                        .id("loser-isolation")
                         .agents(agents)
                         .nodes(nodes)
                         .startNode("parallel")
-                        .rubrics(Map.of("quality", "test-path"))
                         .build();
 
         var result = executor.execute(workflow, new HashMap<>());
 
-        assertThat(result).isInstanceOf(ExecutionResult.Completed.class);
-        assertThat(((ExecutionResult.Completed) result).getExitStatus())
-                .isEqualTo(ExitStatus.SUCCESS);
+        var completed = (ExecutionResult.Completed) result;
+        assertThat(completed.getExitStatus()).isEqualTo(ExitStatus.SUCCESS);
+        assertThat(completed.getFinalState().getContext()).containsEntry("winner_data", "from-b1");
+        assertThat(completed.getFinalState().getContext()).containsEntry("loser_data", "from-b2");
     }
 
+    // — Branch isolation ————————————————————————————————————————————————————
+
     @Test
-    void shouldSkipRubricWhenBranchHasNoRubricId() throws Exception {
-        // Branches without rubricId fall back to keyword heuristics.
-        // "approve" keyword → APPROVE for both → UNANIMOUS → SUCCESS.
+    void shouldIsolateBranchContextFromSiblings() throws Exception {
+        // Both branches read a shared "input" key from parent context.
+        // Each produces a different yield. If isolation breaks, one branch
+        // could see the other's extracted values during execution.
         var agent1 = mock(Agent.class);
         var agent2 = mock(Agent.class);
-        when(agentRegistry.getAgent("r1")).thenReturn(Optional.of(agent1));
-        when(agentRegistry.getAgent("r2")).thenReturn(Optional.of(agent2));
+        when(agentRegistry.getAgent("a1")).thenReturn(Optional.of(agent1));
+        when(agentRegistry.getAgent("a2")).thenReturn(Optional.of(agent2));
         when(agent1.execute(any(), any()))
-                .thenReturn(AgentResponse.TextResponse.of("I approve this"));
+                .thenReturn(
+                        AgentResponse.TextResponse.of(
+                                """
+                {"score": 90, "approved": true, "recommendation": "Good",\
+                 "branch1_out": "from-branch-1"}"""));
         when(agent2.execute(any(), any()))
-                .thenReturn(AgentResponse.TextResponse.of("I approve this"));
+                .thenReturn(
+                        AgentResponse.TextResponse.of(
+                                """
+                {"score": 85, "approved": true, "recommendation": "OK",\
+                 "branch2_out": "from-branch-2"}"""));
 
         var agents =
                 Map.of(
-                        "r1",
-                        AgentConfig.builder().id("r1").role("Reviewer").model("test").build(),
-                        "r2",
-                        AgentConfig.builder().id("r2").role("Reviewer").model("test").build());
+                        "a1", AgentConfig.builder().id("a1").role("Agent").model("test").build(),
+                        "a2", AgentConfig.builder().id("a2").role("Agent").model("test").build());
         var nodes = new HashMap<String, Node>();
         nodes.put(
                 "parallel",
                 ParallelNode.builder("parallel")
-                        .branch("b1", "r1", "Review")
-                        .branch("b2", "r2", "Review")
+                        .branch(
+                                new Branch(
+                                        "b1",
+                                        "a1",
+                                        "Work on {input}",
+                                        null,
+                                        1.0,
+                                        List.of("branch1_out")))
+                        .branch(
+                                new Branch(
+                                        "b2",
+                                        "a2",
+                                        "Work on {input}",
+                                        null,
+                                        1.0,
+                                        List.of("branch2_out")))
                         .consensus(null, ConsensusStrategy.UNANIMOUS)
-                        .transitionRules(
-                                List.of(
-                                        new SuccessTransition("success-end"),
-                                        new FailureTransition(0, "failure-end")))
+                        .transitionRules(List.of(new SuccessTransition("end")))
                         .build());
-        nodes.put("success-end", end("success-end"));
-        nodes.put("failure-end", failEnd("failure-end"));
+        nodes.put("end", end("end"));
         var workflow =
                 Workflow.builder()
-                        .id("no-rubric-consensus")
+                        .id("isolation-test")
                         .agents(agents)
                         .nodes(nodes)
                         .startNode("parallel")
                         .build();
 
-        var result = executor.execute(workflow, new HashMap<>());
+        var initialContext = new HashMap<String, Object>();
+        initialContext.put("input", "shared-data");
 
-        assertThat(result).isInstanceOf(ExecutionResult.Completed.class);
-        assertThat(((ExecutionResult.Completed) result).getExitStatus())
-                .isEqualTo(ExitStatus.SUCCESS);
-    }
+        var result = executor.execute(workflow, initialContext);
 
-    @Test
-    void shouldFailWhenUnanimousConsensusHasOneDissent() throws Exception {
-        // UNANIMOUS requires every branch to approve. Two approve, one rejects.
-        // The single "reject" keyword must break consensus → FAILURE transition.
-        // If the implementation treats UNANIMOUS like MAJORITY_VOTE, this test catches it.
-        var agent1 = mock(Agent.class);
-        var agent2 = mock(Agent.class);
-        var agent3 = mock(Agent.class);
-        when(agentRegistry.getAgent("r1")).thenReturn(Optional.of(agent1));
-        when(agentRegistry.getAgent("r2")).thenReturn(Optional.of(agent2));
-        when(agentRegistry.getAgent("r3")).thenReturn(Optional.of(agent3));
-        when(agent1.execute(any(), any()))
-                .thenReturn(AgentResponse.TextResponse.of("I approve this"));
-        when(agent2.execute(any(), any()))
-                .thenReturn(AgentResponse.TextResponse.of("I approve this"));
-        when(agent3.execute(any(), any()))
-                .thenReturn(AgentResponse.TextResponse.of("I reject this"));
-
-        var agents =
-                Map.of(
-                        "r1",
-                        AgentConfig.builder().id("r1").role("Reviewer").model("test").build(),
-                        "r2",
-                        AgentConfig.builder().id("r2").role("Reviewer").model("test").build(),
-                        "r3",
-                        AgentConfig.builder().id("r3").role("Reviewer").model("test").build());
-        var nodes = new HashMap<String, Node>();
-        nodes.put(
-                "parallel",
-                ParallelNode.builder("parallel")
-                        .branch("b1", "r1", "Review")
-                        .branch("b2", "r2", "Review")
-                        .branch("b3", "r3", "Review")
-                        .consensus(null, ConsensusStrategy.UNANIMOUS)
-                        .transitionRules(
-                                List.of(
-                                        new SuccessTransition("success-end"),
-                                        new FailureTransition(0, "failure-end")))
-                        .build());
-        nodes.put("success-end", end("success-end"));
-        nodes.put("failure-end", failEnd("failure-end"));
-        var workflow =
-                Workflow.builder()
-                        .id("unanimous-dissent")
-                        .agents(agents)
-                        .nodes(nodes)
-                        .startNode("parallel")
-                        .build();
-
-        var result = executor.execute(workflow, new HashMap<>());
-
-        assertThat(result).isInstanceOf(ExecutionResult.Completed.class);
-        assertThat(((ExecutionResult.Completed) result).getExitStatus())
-                .isEqualTo(ExitStatus.FAILURE);
-    }
-
-    @Test
-    void shouldHandleRubricEvaluationFailureGracefully() throws Exception {
-        // rubricEngine throws RubricNotFoundException for branch evaluation.
-        // Executor must fall back to keyword heuristics rather than propagating the error.
-        var agent1 = mock(Agent.class);
-        var agent2 = mock(Agent.class);
-        when(agentRegistry.getAgent("r1")).thenReturn(Optional.of(agent1));
-        when(agentRegistry.getAgent("r2")).thenReturn(Optional.of(agent2));
-        when(agent1.execute(any(), any()))
-                .thenReturn(AgentResponse.TextResponse.of("I approve this"));
-        when(agent2.execute(any(), any()))
-                .thenReturn(AgentResponse.TextResponse.of("I approve this"));
-        when(rubricEngine.exists("quality")).thenReturn(true);
-        when(rubricEngine.evaluate(eq("quality"), any(), any()))
-                .thenThrow(new RubricNotFoundException("Rubric not found: quality"));
-
-        var agents =
-                Map.of(
-                        "r1",
-                        AgentConfig.builder().id("r1").role("Reviewer").model("test").build(),
-                        "r2",
-                        AgentConfig.builder().id("r2").role("Reviewer").model("test").build());
-        var nodes = new HashMap<String, Node>();
-        nodes.put(
-                "parallel",
-                ParallelNode.builder("parallel")
-                        .branch("b1", "r1", "Review", "quality")
-                        .branch("b2", "r2", "Review", "quality")
-                        .consensus(null, ConsensusStrategy.UNANIMOUS)
-                        .transitionRules(
-                                List.of(
-                                        new SuccessTransition("success-end"),
-                                        new FailureTransition(0, "failure-end")))
-                        .build());
-        nodes.put("success-end", end("success-end"));
-        nodes.put("failure-end", failEnd("failure-end"));
-        var workflow =
-                Workflow.builder()
-                        .id("rubric-failure-fallback")
-                        .agents(agents)
-                        .nodes(nodes)
-                        .startNode("parallel")
-                        .rubrics(Map.of("quality", "test-path"))
-                        .build();
-
-        // rubric fails → keyword "approve" fallback → unanimous → SUCCESS
-        var result = executor.execute(workflow, new HashMap<>());
-
-        assertThat(result).isInstanceOf(ExecutionResult.Completed.class);
-        assertThat(((ExecutionResult.Completed) result).getExitStatus())
-                .isEqualTo(ExitStatus.SUCCESS);
+        var completed = (ExecutionResult.Completed) result;
+        assertThat(completed.getExitStatus()).isEqualTo(ExitStatus.SUCCESS);
+        // Both winners' yields merged
+        assertThat(completed.getFinalState().getContext())
+                .containsEntry("branch1_out", "from-branch-1")
+                .containsEntry("branch2_out", "from-branch-2");
+        // Parent input survived untouched
+        assertThat(completed.getFinalState().getContext()).containsEntry("input", "shared-data");
     }
 
     // — helpers ———————————————————————————————————————————————————————————
@@ -360,23 +274,23 @@ class WorkflowExecutorParallelTest extends WorkflowExecutorTestBase {
         var agents =
                 Map.of(
                         "reviewer1",
-                        AgentConfig.builder()
-                                .id("reviewer1")
-                                .role("Reviewer")
-                                .model("test")
-                                .build(),
+                                AgentConfig.builder()
+                                        .id("reviewer1")
+                                        .role("Reviewer")
+                                        .model("test")
+                                        .build(),
                         "reviewer2",
-                        AgentConfig.builder()
-                                .id("reviewer2")
-                                .role("Reviewer")
-                                .model("test")
-                                .build(),
+                                AgentConfig.builder()
+                                        .id("reviewer2")
+                                        .role("Reviewer")
+                                        .model("test")
+                                        .build(),
                         "reviewer3",
-                        AgentConfig.builder()
-                                .id("reviewer3")
-                                .role("Reviewer")
-                                .model("test")
-                                .build());
+                                AgentConfig.builder()
+                                        .id("reviewer3")
+                                        .role("Reviewer")
+                                        .model("test")
+                                        .build());
         var nodes = new HashMap<String, Node>();
         nodes.put(
                 "parallel",

--- a/hensu-core/src/test/java/io/hensu/core/execution/WorkflowExecutorTemplateResolutionTest.java
+++ b/hensu-core/src/test/java/io/hensu/core/execution/WorkflowExecutorTemplateResolutionTest.java
@@ -14,6 +14,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 class WorkflowExecutorTemplateResolutionTest extends WorkflowExecutorTestBase {
 
@@ -150,5 +152,63 @@ class WorkflowExecutorTemplateResolutionTest extends WorkflowExecutorTestBase {
         assertThat(result).isInstanceOf(ExecutionResult.Completed.class);
         assertThat(((ExecutionResult.Completed) result).getFinalState().getContext().get("step1"))
                 .isEqualTo("AI research findings");
+    }
+
+    @Test
+    void shouldResolveWritesVariableBeforeWipingIt() throws Exception {
+        // Regression: a node that writes("article") AND references {article} in its prompt
+        // must resolve the template BEFORE the stale-writes cleanup removes the key.
+        // This is the backtrack-routing pattern: draft → review → refine,
+        // where refine reads the old article to produce a new one.
+        var workflow =
+                WorkflowTest.TestWorkflowBuilder.create("read-modify-write")
+                        .agent(agentCfg())
+                        .startNode(
+                                StandardNode.builder()
+                                        .id("draft")
+                                        .agentId("test-agent")
+                                        .prompt("Write about {topic}")
+                                        .writes(List.of("article"))
+                                        .transitionRules(List.of(new SuccessTransition("refine")))
+                                        .build())
+                        .node(
+                                StandardNode.builder()
+                                        .id("refine")
+                                        .agentId("test-agent")
+                                        .prompt("Refine: {article}")
+                                        .writes(List.of("article"))
+                                        .transitionRules(List.of(new SuccessTransition("end")))
+                                        .build())
+                        .node(end("end"))
+                        .build();
+
+        when(agentRegistry.getAgent("test-agent")).thenReturn(Optional.of(mockAgent));
+
+        // draft produces the initial article
+        when(mockAgent.execute(any(), any()))
+                .thenReturn(
+                        AgentResponse.TextResponse.of(
+                                """
+                                {"article": "First draft content"}"""))
+                .thenReturn(
+                        AgentResponse.TextResponse.of(
+                                """
+                                {"article": "Refined content"}"""));
+
+        var ctx = new HashMap<String, Object>();
+        ctx.put("topic", "AI");
+        var result = executor.execute(workflow, ctx);
+
+        assertThat(result).isInstanceOf(ExecutionResult.Completed.class);
+
+        // Verify refine node received the article in its prompt, not an empty string
+        var captor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(mockAgent, Mockito.times(2)).execute(captor.capture(), any());
+        String refinePrompt = captor.getAllValues().get(1);
+        assertThat(refinePrompt).contains("First draft content");
+
+        // Final state should have the refined article
+        var finalState = ((ExecutionResult.Completed) result).getFinalState();
+        assertThat(finalState.getContext().get("article")).isEqualTo("Refined content");
     }
 }

--- a/hensu-core/src/test/java/io/hensu/core/execution/parallel/ConsensusEvaluatorTest.java
+++ b/hensu-core/src/test/java/io/hensu/core/execution/parallel/ConsensusEvaluatorTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.when;
 import io.hensu.core.agent.Agent;
 import io.hensu.core.agent.AgentRegistry;
 import io.hensu.core.agent.AgentResponse;
+import io.hensu.core.execution.EngineVariables;
+import io.hensu.core.execution.ExecutionListener;
 import io.hensu.core.execution.executor.NodeResult;
 import io.hensu.core.execution.result.ResultStatus;
 import io.hensu.core.state.HensuState;
@@ -26,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ConsensusEvaluatorTest {
 
     private ConsensusEvaluator evaluator;
+    private final ExecutionListener listener = ExecutionListener.NOOP;
 
     @BeforeEach
     void setUp() {
@@ -34,114 +37,93 @@ class ConsensusEvaluatorTest {
 
     // -- Helpers --
 
-    private static BranchResult branchWithOutput(String branchId, String output) {
-        return new BranchResult(branchId, new NodeResult(ResultStatus.SUCCESS, output, Map.of()));
+    private static BranchResult branchWithYields(
+            String branchId, String output, Map<String, Object> yields) {
+        return new BranchResult(
+                branchId, new NodeResult(ResultStatus.SUCCESS, output, Map.of()), yields, 1.0);
     }
 
-    private static BranchResult branchWithMetadata(
-            String branchId, String output, Map<String, Object> metadata) {
-        return new BranchResult(branchId, new NodeResult(ResultStatus.SUCCESS, output, metadata));
+    private static BranchResult branchWithYields(
+            String branchId, String output, Map<String, Object> yields, double weight) {
+        return new BranchResult(
+                branchId, new NodeResult(ResultStatus.SUCCESS, output, Map.of()), yields, weight);
     }
 
-    private static BranchResult branchWithRubric(
-            String branchId, String output, double rubricScore, boolean rubricPassed) {
-        Map<String, Object> metadata = new HashMap<>();
-        metadata.put("rubric_score", rubricScore);
-        metadata.put("rubric_passed", rubricPassed);
-        metadata.put("rubric_id", "test-rubric");
-        return new BranchResult(branchId, new NodeResult(ResultStatus.SUCCESS, output, metadata));
+    private static BranchResult approving(String branchId, double score) {
+        return branchWithYields(
+                branchId,
+                "output",
+                Map.of(EngineVariables.SCORE, score, EngineVariables.APPROVED, true));
+    }
+
+    private static BranchResult rejecting(String branchId, double score) {
+        return branchWithYields(
+                branchId,
+                "output",
+                Map.of(EngineVariables.SCORE, score, EngineVariables.APPROVED, false));
     }
 
     @Nested
     class VoteExtractionTest {
 
         @Test
-        void shouldPreferRubricScoreOverTextParsing() {
-            // Given: rubric says APPROVE, text says "reject"
-            BranchResult br = branchWithRubric("b1", "I reject this. Score: 20", 85.0, true);
+        void shouldReadScoreAndApprovalFromYields() {
+            BranchResult br =
+                    branchWithYields(
+                            "b1",
+                            "output",
+                            Map.of(EngineVariables.SCORE, 85.0, EngineVariables.APPROVED, true));
             ConsensusConfig config =
                     new ConsensusConfig(null, ConsensusStrategy.MAJORITY_VOTE, null);
 
-            // When
             Map<String, ConsensusResult.Vote> votes = evaluator.extractVotes(List.of(br), config);
 
-            // Then: rubric overrides text heuristics
             assertThat(votes.get("b1").voteType()).isEqualTo(ConsensusResult.VoteType.APPROVE);
             assertThat(votes.get("b1").score()).isEqualTo(85.0);
         }
 
         @Test
-        void shouldFallbackToTextParsingWhenNoRubric() {
-            // Given: no rubric metadata, output contains "approve" keyword
-            BranchResult br = branchWithOutput("b1", "I approve this content");
+        void shouldHandleStringlyTypedScoreFromLlm() {
+            // LLMs frequently return numbers as strings: {"score": "85"} instead of {"score": 85}
+            // Prod code uses `instanceof Number` which silently defaults to 0.0 for strings.
+            BranchResult br =
+                    branchWithYields(
+                            "b1",
+                            "output",
+                            Map.of(EngineVariables.SCORE, "85", EngineVariables.APPROVED, true));
             ConsensusConfig config =
                     new ConsensusConfig(null, ConsensusStrategy.MAJORITY_VOTE, null);
 
-            // When
             Map<String, ConsensusResult.Vote> votes = evaluator.extractVotes(List.of(br), config);
 
-            // Then: keyword-based detection
+            // Current behavior: string score defaults to 0.0 (not parsed as number)
+            assertThat(votes.get("b1").score()).isEqualTo(0.0);
+            // Vote type still comes from explicit approved=true
             assertThat(votes.get("b1").voteType()).isEqualTo(ConsensusResult.VoteType.APPROVE);
         }
 
         @Test
-        void shouldExtractScoreFromMetadata() {
-            // Given: explicit score in metadata
-            BranchResult br = branchWithMetadata("b1", "Some output", Map.of("score", 75.0));
+        void shouldDeriveApprovalFromScoreWhenApprovedFieldMissing() {
+            // score=85 >= default threshold 70 -> APPROVE
+            BranchResult br = branchWithYields("b1", "output", Map.of(EngineVariables.SCORE, 85.0));
             ConsensusConfig config =
                     new ConsensusConfig(null, ConsensusStrategy.MAJORITY_VOTE, null);
 
-            // When
             Map<String, ConsensusResult.Vote> votes = evaluator.extractVotes(List.of(br), config);
 
-            // Then
-            assertThat(votes.get("b1").score()).isEqualTo(75.0);
+            assertThat(votes.get("b1").voteType()).isEqualTo(ConsensusResult.VoteType.APPROVE);
         }
 
         @Test
-        void shouldExtractScoreFromOutputPattern() {
-            // Given: score embedded in output text
-            BranchResult br = branchWithOutput("b1", "Analysis complete. Score: 82.5 out of 100");
+        void shouldDefaultToZeroScoreWhenYieldsEmpty() {
+            BranchResult br = branchWithYields("b1", "output", Map.of());
             ConsensusConfig config =
                     new ConsensusConfig(null, ConsensusStrategy.MAJORITY_VOTE, null);
 
-            // When
             Map<String, ConsensusResult.Vote> votes = evaluator.extractVotes(List.of(br), config);
 
-            // Then
-            assertThat(votes.get("b1").score()).isEqualTo(82.5);
-        }
-
-        @Test
-        void shouldThrowClassCastExceptionWhenWeightIsString() {
-            // Production code: ((Number) metadata.get("weight")).doubleValue()
-            // If weight arrives as a String (common from JSON parsers without type info),
-            // this hard cast throws ClassCastException and kills the entire evaluation.
-            // This test pins the current behavior; the fix is to use Number instanceof check.
-            Map<String, Object> metadata = new HashMap<>();
-            metadata.put("score", 90.0);
-            metadata.put("weight", "0.6"); // String, not Double — the bug trigger
-            BranchResult br = branchWithMetadata("b1", "I approve", metadata);
-            ConsensusConfig config =
-                    new ConsensusConfig(null, ConsensusStrategy.WEIGHTED_VOTE, 0.5);
-
-            assertThatThrownBy(() -> evaluator.extractVotes(List.of(br), config))
-                    .isInstanceOf(ClassCastException.class);
-        }
-
-        @Test
-        void shouldDefaultToNeutralScoreWhenNothingFound() {
-            // Given: no score in metadata, no patterns in output, no keywords
-            BranchResult br = branchWithOutput("b1", "Some generic response");
-            ConsensusConfig config =
-                    new ConsensusConfig(null, ConsensusStrategy.MAJORITY_VOTE, null);
-
-            // When
-            Map<String, ConsensusResult.Vote> votes = evaluator.extractVotes(List.of(br), config);
-
-            // Then: neutral score (50.0) → ABSTAIN (between threshold and threshold-20)
-            assertThat(votes.get("b1").score()).isEqualTo(50.0);
-            assertThat(votes.get("b1").voteType()).isEqualTo(ConsensusResult.VoteType.ABSTAIN);
+            assertThat(votes.get("b1").score()).isEqualTo(0.0);
+            assertThat(votes.get("b1").voteType()).isEqualTo(ConsensusResult.VoteType.REJECT);
         }
     }
 
@@ -151,81 +133,36 @@ class ConsensusEvaluatorTest {
         @Mock private AgentRegistry agentRegistry;
 
         @Test
-        void shouldReachMajorityWithDefaultThreshold() throws Exception {
-            // Given: 2/3 approve, threshold=null (default 0.5 → need ceil(3*0.5)=2)
+        void shouldNotReachMajorityOnExactTieAtFiftyPercent() throws Exception {
+            // 2/4 approve at 50% threshold -> need >2.0 -> 2 > 2 is false (strict)
             List<BranchResult> results =
                     List.of(
-                            branchWithOutput("b1", "I approve this"),
-                            branchWithOutput("b2", "I approve this"),
-                            branchWithOutput("b3", "I reject this"));
+                            approving("b1", 85.0),
+                            approving("b2", 80.0),
+                            rejecting("b3", 30.0),
+                            rejecting("b4", 25.0));
             ConsensusConfig config =
-                    new ConsensusConfig(null, ConsensusStrategy.MAJORITY_VOTE, null);
+                    new ConsensusConfig(null, ConsensusStrategy.MAJORITY_VOTE, 0.5);
 
-            // When
             ConsensusResult result =
-                    evaluator.evaluate(config, results, emptyState(), agentRegistry);
+                    evaluator.evaluate(config, results, emptyState(), agentRegistry, listener);
 
-            // Then
-            assertThat(result.consensusReached()).isTrue();
-        }
-
-        @Test
-        void shouldNotReachMajorityWhenCustomThresholdNotMet() throws Exception {
-            // Given: 2/3 approve, threshold=0.8 → need ceil(3*0.8)=3
-            List<BranchResult> results =
-                    List.of(
-                            branchWithOutput("b1", "I approve this"),
-                            branchWithOutput("b2", "I approve this"),
-                            branchWithOutput("b3", "I reject this"));
-            ConsensusConfig config =
-                    new ConsensusConfig(null, ConsensusStrategy.MAJORITY_VOTE, 0.8);
-
-            // When
-            ConsensusResult result =
-                    evaluator.evaluate(config, results, emptyState(), agentRegistry);
-
-            // Then: 2 approvals < 3 required
             assertThat(result.consensusReached()).isFalse();
         }
 
         @Test
-        void shouldReachMajorityWhenCustomThresholdMet() throws Exception {
-            // Given: 3/3 approve, threshold=0.8 → need ceil(3*0.8)=3
+        void shouldNotReachMajorityWhenCustomThresholdNotMet() throws Exception {
+            // 2/3 approve, threshold=0.8 -> need >2.4 -> 2 > 2 is false
             List<BranchResult> results =
-                    List.of(
-                            branchWithOutput("b1", "I approve"),
-                            branchWithOutput("b2", "I accept"),
-                            branchWithOutput("b3", "I pass this"));
+                    List.of(approving("b1", 85.0), approving("b2", 80.0), rejecting("b3", 30.0));
             ConsensusConfig config =
                     new ConsensusConfig(null, ConsensusStrategy.MAJORITY_VOTE, 0.8);
 
-            // When
             ConsensusResult result =
-                    evaluator.evaluate(config, results, emptyState(), agentRegistry);
+                    evaluator.evaluate(config, results, emptyState(), agentRegistry, listener);
 
-            // Then
-            assertThat(result.consensusReached()).isTrue();
-        }
-
-        @Test
-        void shouldUseRubricScoreForMajorityVote() throws Exception {
-            // Given: 2 rubric-passed, 1 rubric-failed
-            List<BranchResult> results =
-                    List.of(
-                            branchWithRubric("b1", "output", 90.0, true),
-                            branchWithRubric("b2", "output", 85.0, true),
-                            branchWithRubric("b3", "output", 40.0, false));
-            ConsensusConfig config =
-                    new ConsensusConfig(null, ConsensusStrategy.MAJORITY_VOTE, null);
-
-            // When
-            ConsensusResult result =
-                    evaluator.evaluate(config, results, emptyState(), agentRegistry);
-
-            // Then: 2/3 approve → consensus
-            assertThat(result.consensusReached()).isTrue();
-            assertThat(result.approveCount()).isEqualTo(2);
-            assertThat(result.rejectCount()).isEqualTo(1);
+            assertThat(result.consensusReached()).isFalse();
+            assertThat(result.reasoning()).contains("threshold=80%");
         }
     }
 
@@ -236,74 +173,26 @@ class ConsensusEvaluatorTest {
 
         @Test
         void shouldReachUnanimousWhenAllApprove() throws Exception {
-            // Given: all 3 branches approve
             List<BranchResult> results =
-                    List.of(
-                            branchWithOutput("b1", "I approve"),
-                            branchWithOutput("b2", "I accept this"),
-                            branchWithOutput("b3", "I pass"));
+                    List.of(approving("b1", 95.0), approving("b2", 80.0), approving("b3", 72.0));
             ConsensusConfig config = new ConsensusConfig(null, ConsensusStrategy.UNANIMOUS, null);
 
-            // When
             ConsensusResult result =
-                    evaluator.evaluate(config, results, emptyState(), agentRegistry);
+                    evaluator.evaluate(config, results, emptyState(), agentRegistry, listener);
 
-            // Then
             assertThat(result.consensusReached()).isTrue();
         }
 
         @Test
-        void shouldNotReachUnanimousWhenAnyRejects() throws Exception {
-            // Given: 2 approve, 1 rejects
-            List<BranchResult> results =
-                    List.of(
-                            branchWithOutput("b1", "I approve"),
-                            branchWithOutput("b2", "I approve"),
-                            branchWithOutput("b3", "I reject this"));
+        void shouldNotReachUnanimousOnEmptyVotes() throws Exception {
+            // Stream.allMatch() returns true on empty streams -- our code must guard against this
             ConsensusConfig config = new ConsensusConfig(null, ConsensusStrategy.UNANIMOUS, null);
 
-            // When
             ConsensusResult result =
-                    evaluator.evaluate(config, results, emptyState(), agentRegistry);
+                    evaluator.evaluate(config, List.of(), emptyState(), agentRegistry, listener);
 
-            // Then
             assertThat(result.consensusReached()).isFalse();
-        }
-
-        @Test
-        void shouldNotReachUnanimousWhenAnyAbstains() throws Exception {
-            // Given: 2 approve, 1 neutral (no keywords, neutral score → ABSTAIN)
-            List<BranchResult> results =
-                    List.of(
-                            branchWithOutput("b1", "I approve"),
-                            branchWithOutput("b2", "I approve"),
-                            branchWithOutput("b3", "Hmm, not sure about this"));
-            ConsensusConfig config = new ConsensusConfig(null, ConsensusStrategy.UNANIMOUS, null);
-
-            // When
-            ConsensusResult result =
-                    evaluator.evaluate(config, results, emptyState(), agentRegistry);
-
-            // Then: ABSTAIN ≠ APPROVE → not unanimous
-            assertThat(result.consensusReached()).isFalse();
-        }
-
-        @Test
-        void shouldUseRubricScoreForUnanimous() throws Exception {
-            // Given: all 3 branches pass rubric
-            List<BranchResult> results =
-                    List.of(
-                            branchWithRubric("b1", "output", 95.0, true),
-                            branchWithRubric("b2", "output", 80.0, true),
-                            branchWithRubric("b3", "output", 72.0, true));
-            ConsensusConfig config = new ConsensusConfig(null, ConsensusStrategy.UNANIMOUS, null);
-
-            // When
-            ConsensusResult result =
-                    evaluator.evaluate(config, results, emptyState(), agentRegistry);
-
-            // Then: all rubric-passed → unanimous
-            assertThat(result.consensusReached()).isTrue();
+            assertThat(result.reasoning()).contains("no branches");
         }
     }
 
@@ -313,94 +202,79 @@ class ConsensusEvaluatorTest {
         @Mock private AgentRegistry agentRegistry;
 
         @Test
-        void shouldReachWeightedConsensusAboveThreshold() throws Exception {
-            // Given: high-score approver (90*0.6=54) vs low-score rejector (20*0.4=8)
-            // approveRatio = 54/(54+8) = 0.87 > 0.5
+        void shouldReachConsensusWhenApproveWeightDominates() throws Exception {
+            // b1: approve (70*0.5=35), b2: approve (80*0.5=40), b3: reject (99*0.5=49.5)
+            // approveRatio = 75/(75+49.5) = 0.60 > 0.5 -> consensus reached
             List<BranchResult> results =
                     List.of(
-                            branchWithMetadata(
-                                    "b1", "I approve", Map.of("score", 90.0, "weight", 0.6)),
-                            branchWithMetadata(
-                                    "b2", "I reject", Map.of("score", 20.0, "weight", 0.4)));
+                            branchWithYields(
+                                    "b1",
+                                    "output",
+                                    Map.of(
+                                            EngineVariables.SCORE,
+                                            70.0,
+                                            EngineVariables.APPROVED,
+                                            true),
+                                    0.5),
+                            branchWithYields(
+                                    "b2",
+                                    "best output",
+                                    Map.of(
+                                            EngineVariables.SCORE,
+                                            80.0,
+                                            EngineVariables.APPROVED,
+                                            true),
+                                    0.5),
+                            branchWithYields(
+                                    "b3",
+                                    "reject output",
+                                    Map.of(
+                                            EngineVariables.SCORE,
+                                            99.0,
+                                            EngineVariables.APPROVED,
+                                            false),
+                                    0.5));
             ConsensusConfig config =
                     new ConsensusConfig(null, ConsensusStrategy.WEIGHTED_VOTE, 0.5);
 
-            // When
             ConsensusResult result =
-                    evaluator.evaluate(config, results, emptyState(), agentRegistry);
+                    evaluator.evaluate(config, results, emptyState(), agentRegistry, listener);
 
-            // Then
             assertThat(result.consensusReached()).isTrue();
         }
 
         @Test
-        void shouldNotReachWeightedConsensusBelowThreshold() throws Exception {
-            // Given: low-score approver (30*0.3=9) vs high-score rejector (95*0.7=66.5)
-            // approveRatio = 9/(9+66.5) = 0.119 < 0.5
+        void shouldHandleZeroTotalWeight() throws Exception {
+            // All weights are 0.0 -> totalWeighted = 0 -> approveRatio = 0 -> no consensus
+            // Guards against NaN from 0/0 division
             List<BranchResult> results =
                     List.of(
-                            branchWithMetadata(
-                                    "b1", "I approve", Map.of("score", 30.0, "weight", 0.3)),
-                            branchWithMetadata(
-                                    "b2", "I reject", Map.of("score", 95.0, "weight", 0.7)));
+                            branchWithYields(
+                                    "b1",
+                                    "output",
+                                    Map.of(
+                                            EngineVariables.SCORE,
+                                            90.0,
+                                            EngineVariables.APPROVED,
+                                            true),
+                                    0.0),
+                            branchWithYields(
+                                    "b2",
+                                    "output",
+                                    Map.of(
+                                            EngineVariables.SCORE,
+                                            80.0,
+                                            EngineVariables.APPROVED,
+                                            true),
+                                    0.0));
             ConsensusConfig config =
                     new ConsensusConfig(null, ConsensusStrategy.WEIGHTED_VOTE, 0.5);
 
-            // When
             ConsensusResult result =
-                    evaluator.evaluate(config, results, emptyState(), agentRegistry);
+                    evaluator.evaluate(config, results, emptyState(), agentRegistry, listener);
 
-            // Then
             assertThat(result.consensusReached()).isFalse();
-        }
-
-        @Test
-        void shouldIgnoreAbstainInWeightedCalculation() throws Exception {
-            // Given: 1 approve (score=90), 1 abstain (neutral, no keywords)
-            // Only approve contributes → ratio = 1.0
-            List<BranchResult> results =
-                    List.of(
-                            branchWithOutput("b1", "I approve. Score: 90"),
-                            branchWithOutput("b2", "Some neutral comment"));
-            ConsensusConfig config =
-                    new ConsensusConfig(null, ConsensusStrategy.WEIGHTED_VOTE, 0.5);
-
-            // When
-            ConsensusResult result =
-                    evaluator.evaluate(config, results, emptyState(), agentRegistry);
-
-            // Then: ABSTAIN excluded, only approve counted → ratio = 1.0 > 0.5
-            assertThat(result.consensusReached()).isTrue();
-        }
-
-        @Test
-        void shouldUseRubricScoreForWeightedVote() throws Exception {
-            // Given: rubric-scored branches
-            // b1: passed (score 85, weight 0.5) → weighted: 85*0.5 = 42.5
-            // b2: failed (score 40, weight 0.5) → weighted: 40*0.5 = 20.0
-            // approveRatio = 42.5/(42.5+20.0) = 0.68 > 0.5
-            Map<String, Object> meta1 = new HashMap<>();
-            meta1.put("rubric_score", 85.0);
-            meta1.put("rubric_passed", true);
-            meta1.put("weight", 0.5);
-            Map<String, Object> meta2 = new HashMap<>();
-            meta2.put("rubric_score", 40.0);
-            meta2.put("rubric_passed", false);
-            meta2.put("weight", 0.5);
-
-            List<BranchResult> results =
-                    List.of(
-                            branchWithMetadata("b1", "output", meta1),
-                            branchWithMetadata("b2", "output", meta2));
-            ConsensusConfig config =
-                    new ConsensusConfig(null, ConsensusStrategy.WEIGHTED_VOTE, 0.5);
-
-            // When
-            ConsensusResult result =
-                    evaluator.evaluate(config, results, emptyState(), agentRegistry);
-
-            // Then
-            assertThat(result.consensusReached()).isTrue();
+            assertThat(result.reasoning()).doesNotContain("NaN");
         }
     }
 
@@ -412,67 +286,135 @@ class ConsensusEvaluatorTest {
 
         @Test
         void shouldApproveWhenJudgeApproves() throws Exception {
-            // Given
             when(agentRegistry.getAgent("judge")).thenReturn(Optional.of(judgeAgent));
+            String judgeJson =
+                    """
+                    {"decision": true, "winning_branch": "b1", \
+                    "reasoning": "Good quality"}""";
             when(judgeAgent.execute(any(), any()))
-                    .thenReturn(
-                            AgentResponse.TextResponse.of(
-                                    """
-                                    {"decision": "approve", "winning_branch": "b1", \
-                                    "reasoning": "Good quality", "final_output": "Approved"}"""));
+                    .thenReturn(AgentResponse.TextResponse.of(judgeJson));
 
             List<BranchResult> results =
                     List.of(
-                            branchWithOutput("b1", "I approve. Score: 90"),
-                            branchWithOutput("b2", "I reject. Score: 30"));
+                            branchWithYields("b1", "proposal A", Map.of("proposal", "A")),
+                            branchWithYields("b2", "proposal B", Map.of("proposal", "B")));
             ConsensusConfig config =
                     new ConsensusConfig("judge", ConsensusStrategy.JUDGE_DECIDES, null);
 
-            // When
             ConsensusResult result =
-                    evaluator.evaluate(config, results, emptyState(), agentRegistry);
+                    evaluator.evaluate(config, results, emptyState(), agentRegistry, listener);
 
-            // Then
             assertThat(result.consensusReached()).isTrue();
             assertThat(result.winningBranchId()).isEqualTo("b1");
+            assertThat(result.finalOutput()).isEqualTo(judgeJson);
+            assertThat(result.reasoning()).isEqualTo("Good quality");
         }
 
         @Test
         void shouldRejectWhenJudgeRejects() throws Exception {
-            // Given
+            when(agentRegistry.getAgent("judge")).thenReturn(Optional.of(judgeAgent));
+            String judgeJson =
+                    """
+                    {"decision": false, "winning_branch": null, \
+                    "reasoning": "Poor quality"}""";
+            when(judgeAgent.execute(any(), any()))
+                    .thenReturn(AgentResponse.TextResponse.of(judgeJson));
+
+            List<BranchResult> results =
+                    List.of(
+                            branchWithYields("b1", "proposal A", Map.of("proposal", "A")),
+                            branchWithYields("b2", "proposal B", Map.of("proposal", "B")));
+            ConsensusConfig config =
+                    new ConsensusConfig("judge", ConsensusStrategy.JUDGE_DECIDES, null);
+
+            ConsensusResult result =
+                    evaluator.evaluate(config, results, emptyState(), agentRegistry, listener);
+
+            assertThat(result.consensusReached()).isFalse();
+            assertThat(result.finalOutput()).isEqualTo(judgeJson);
+            assertThat(result.reasoning()).isEqualTo("Poor quality");
+        }
+
+        @Test
+        void shouldRejectUnknownWinningBranch() throws Exception {
             when(agentRegistry.getAgent("judge")).thenReturn(Optional.of(judgeAgent));
             when(judgeAgent.execute(any(), any()))
                     .thenReturn(
                             AgentResponse.TextResponse.of(
                                     """
-                                    {"decision": "reject", "winning_branch": null, \
-                                    "reasoning": "Poor quality", "final_output": "Rejected"}"""));
+                            {"decision": true, "winning_branch": "ghost_branch", \
+                            "reasoning": "Best analysis"}"""));
 
             List<BranchResult> results =
-                    List.of(
-                            branchWithOutput("b1", "I approve. Score: 50"),
-                            branchWithOutput("b2", "I reject. Score: 30"));
+                    List.of(branchWithYields("b1", "proposal A", Map.of("proposal", "A")));
             ConsensusConfig config =
                     new ConsensusConfig("judge", ConsensusStrategy.JUDGE_DECIDES, null);
 
-            // When
             ConsensusResult result =
-                    evaluator.evaluate(config, results, emptyState(), agentRegistry);
+                    evaluator.evaluate(config, results, emptyState(), agentRegistry, listener);
 
-            // Then
+            // Ghost branch ID must be rejected -- winningBranchId should be null
+            assertThat(result.consensusReached()).isTrue();
+            assertThat(result.winningBranchId()).isNull();
+        }
+
+        @Test
+        void shouldUseRawJudgeResponseAsFinalOutput() throws Exception {
+            when(agentRegistry.getAgent("judge")).thenReturn(Optional.of(judgeAgent));
+            String rawResponse =
+                    """
+                    {"decision": true, "winning_branch": "b1", \
+                    "reasoning": "OK"}""";
+            when(judgeAgent.execute(any(), any()))
+                    .thenReturn(AgentResponse.TextResponse.of(rawResponse));
+
+            List<BranchResult> results =
+                    List.of(branchWithYields("b1", "proposal A", Map.of("proposal", "A")));
+            ConsensusConfig config =
+                    new ConsensusConfig("judge", ConsensusStrategy.JUDGE_DECIDES, null);
+
+            ConsensusResult result =
+                    evaluator.evaluate(config, results, emptyState(), agentRegistry, listener);
+
+            // finalOutput is always the raw judge response (no final_output extraction)
+            assertThat(result.finalOutput()).isEqualTo(rawResponse);
+        }
+
+        @Test
+        void shouldDegradeGracefullyOnInvalidJudgeJson() throws Exception {
+            // Judge returns prose instead of JSON -> extractOutputParams extracts nothing
+            // -> decision is not Boolean -> consensusReached=false, fallback reasoning
+            when(agentRegistry.getAgent("judge")).thenReturn(Optional.of(judgeAgent));
+            when(judgeAgent.execute(any(), any()))
+                    .thenReturn(
+                            AgentResponse.TextResponse.of(
+                                    "I think branch b1 is better but I'm not sure."));
+
+            List<BranchResult> results =
+                    List.of(
+                            branchWithYields("b1", "proposal A", Map.of("proposal", "A")),
+                            branchWithYields("b2", "proposal B", Map.of("proposal", "B")));
+            ConsensusConfig config =
+                    new ConsensusConfig("judge", ConsensusStrategy.JUDGE_DECIDES, null);
+
+            ConsensusResult result =
+                    evaluator.evaluate(config, results, emptyState(), agentRegistry, listener);
+
             assertThat(result.consensusReached()).isFalse();
+            assertThat(result.reasoning()).contains("rejected");
         }
 
         @Test
         void shouldThrowWhenJudgeAgentMissing() {
-            // Given
-            List<BranchResult> results = List.of(branchWithOutput("b1", "output"));
+            List<BranchResult> results =
+                    List.of(branchWithYields("b1", "proposal A", Map.of("proposal", "A")));
             ConsensusConfig config =
                     new ConsensusConfig(null, ConsensusStrategy.JUDGE_DECIDES, null);
 
-            // When/Then
             assertThatThrownBy(
-                            () -> evaluator.evaluate(config, results, emptyState(), agentRegistry))
+                            () ->
+                                    evaluator.evaluate(
+                                            config, results, emptyState(), agentRegistry, listener))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessageContaining("judge agent ID");
         }

--- a/hensu-core/src/test/java/io/hensu/core/execution/pipeline/RubricPostProcessorTest.java
+++ b/hensu-core/src/test/java/io/hensu/core/execution/pipeline/RubricPostProcessorTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import io.hensu.core.execution.EngineVariables;
 import io.hensu.core.execution.executor.ExecutionContext;
 import io.hensu.core.execution.executor.NodeResult;
 import io.hensu.core.execution.result.ExecutionHistory;
@@ -247,7 +248,7 @@ class RubricPostProcessorTest {
                             .build();
 
             var ctx = contextWithNode(node);
-            ctx.state().getContext().put("score", 45.0);
+            ctx.state().getContext().put(EngineVariables.SCORE, 45.0);
             mockRubricEvaluation(45.0, false);
 
             var result = processor.process(ctx);

--- a/hensu-core/src/test/java/io/hensu/core/rubric/evaluator/ScoreExtractingEvaluatorTest.java
+++ b/hensu-core/src/test/java/io/hensu/core/rubric/evaluator/ScoreExtractingEvaluatorTest.java
@@ -2,6 +2,7 @@ package io.hensu.core.rubric.evaluator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.hensu.core.execution.EngineVariables;
 import io.hensu.core.execution.executor.NodeResult;
 import io.hensu.core.rubric.model.Criterion;
 import java.util.HashMap;
@@ -24,7 +25,7 @@ class ScoreExtractingEvaluatorTest {
     @Test
     void shouldReturnZeroForFailedNodeResult() {
         Map<String, Object> context = new HashMap<>();
-        context.put("score", 95.0);
+        context.put(EngineVariables.SCORE, 95.0);
 
         double score = evaluator.evaluate(criterion, NodeResult.failure("agent error"), context);
 
@@ -41,7 +42,7 @@ class ScoreExtractingEvaluatorTest {
     @Test
     void shouldReturnNumericScoreDirectly() {
         Map<String, Object> context = new HashMap<>();
-        context.put("score", 85.0);
+        context.put(EngineVariables.SCORE, 85.0);
 
         double score = evaluator.evaluate(criterion, NodeResult.empty(), context);
 
@@ -51,7 +52,7 @@ class ScoreExtractingEvaluatorTest {
     @Test
     void shouldParseScoreFromString() {
         Map<String, Object> context = new HashMap<>();
-        context.put("score", "85.0");
+        context.put(EngineVariables.SCORE, "85.0");
 
         double score = evaluator.evaluate(criterion, NodeResult.empty(), context);
 
@@ -61,7 +62,7 @@ class ScoreExtractingEvaluatorTest {
     @Test
     void shouldReturnZeroForUnparsableScoreString() {
         Map<String, Object> context = new HashMap<>();
-        context.put("score", "N/A");
+        context.put(EngineVariables.SCORE, "N/A");
 
         double score = evaluator.evaluate(criterion, NodeResult.empty(), context);
 
@@ -71,8 +72,8 @@ class ScoreExtractingEvaluatorTest {
     @Test
     void shouldAccumulateRecommendationWhenScoreBelowThreshold() {
         Map<String, Object> context = new HashMap<>();
-        context.put("score", 50.0);
-        context.put("recommendation", "Add more detail to the answer.");
+        context.put(EngineVariables.SCORE, 50.0);
+        context.put(EngineVariables.RECOMMENDATION, "Add more detail to the answer.");
 
         evaluator.evaluate(criterion, NodeResult.empty(), context);
 
@@ -90,8 +91,8 @@ class ScoreExtractingEvaluatorTest {
     @Test
     void shouldNotAccumulateRecommendationWhenScoreMeetsThreshold() {
         Map<String, Object> context = new HashMap<>();
-        context.put("score", 70.0);
-        context.put("recommendation", "This looks fine.");
+        context.put(EngineVariables.SCORE, 70.0);
+        context.put(EngineVariables.RECOMMENDATION, "This looks fine.");
 
         evaluator.evaluate(criterion, NodeResult.empty(), context);
 
@@ -101,8 +102,8 @@ class ScoreExtractingEvaluatorTest {
     @Test
     void shouldIgnoreBlankRecommendation() {
         Map<String, Object> context = new HashMap<>();
-        context.put("score", 50.0);
-        context.put("recommendation", "   ");
+        context.put(EngineVariables.SCORE, 50.0);
+        context.put(EngineVariables.RECOMMENDATION, "   ");
 
         evaluator.evaluate(criterion, NodeResult.empty(), context);
 
@@ -114,11 +115,11 @@ class ScoreExtractingEvaluatorTest {
         Criterion second = Criterion.builder().id("clarity").name("Clarity").minScore(70.0).build();
 
         Map<String, Object> context = new HashMap<>();
-        context.put("score", 50.0);
-        context.put("recommendation", "First fix.");
+        context.put(EngineVariables.SCORE, 50.0);
+        context.put(EngineVariables.RECOMMENDATION, "First fix.");
         evaluator.evaluate(criterion, NodeResult.empty(), context);
 
-        context.put("recommendation", "Second fix.");
+        context.put(EngineVariables.RECOMMENDATION, "Second fix.");
         evaluator.evaluate(second, NodeResult.empty(), context);
 
         List<String> recs =
@@ -129,8 +130,8 @@ class ScoreExtractingEvaluatorTest {
     @Test
     void shouldNotCrashWhenRecommendationsKeyHoldsWrongType() {
         Map<String, Object> context = new HashMap<>();
-        context.put("score", 50.0);
-        context.put("recommendation", "Some fix.");
+        context.put(EngineVariables.SCORE, 50.0);
+        context.put(EngineVariables.RECOMMENDATION, "Some fix.");
         context.put(ScoreExtractingEvaluator.RECOMMENDATIONS_KEY, "not-a-list");
 
         double score = evaluator.evaluate(criterion, NodeResult.empty(), context);

--- a/hensu-core/src/test/java/io/hensu/core/state/HensuSnapshotTest.java
+++ b/hensu-core/src/test/java/io/hensu/core/state/HensuSnapshotTest.java
@@ -4,283 +4,91 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.hensu.core.execution.result.ExecutionHistory;
-import io.hensu.core.plan.PlanSnapshot;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.Map;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class HensuSnapshotTest {
 
-    @Nested
-    class ConstructorValidation {
-
-        @Test
-        void shouldThrowWhenWorkflowIdIsNull() {
-            assertThatThrownBy(
-                            () ->
-                                    new HensuSnapshot(
-                                            null,
-                                            "exec-1",
-                                            "node-1",
-                                            Map.of(),
-                                            new ExecutionHistory(),
-                                            null,
-                                            Instant.now(),
-                                            null))
-                    .isInstanceOf(NullPointerException.class)
-                    .hasMessageContaining("workflowId");
-        }
-
-        @Test
-        void shouldThrowWhenExecutionIdIsNull() {
-            assertThatThrownBy(
-                            () ->
-                                    new HensuSnapshot(
-                                            "workflow-1",
-                                            null,
-                                            "node-1",
-                                            Map.of(),
-                                            new ExecutionHistory(),
-                                            null,
-                                            Instant.now(),
-                                            null))
-                    .isInstanceOf(NullPointerException.class)
-                    .hasMessageContaining("executionId");
-        }
-
-        @Test
-        void shouldAcceptNullCurrentNodeId() {
-            HensuSnapshot snapshot =
-                    new HensuSnapshot(
-                            "workflow-1",
-                            "exec-1",
-                            null,
-                            Map.of(),
-                            new ExecutionHistory(),
-                            null,
-                            Instant.now(),
-                            null);
-
-            assertThat(snapshot.currentNodeId()).isNull();
-            assertThat(snapshot.isCompleted()).isTrue();
-        }
-
-        @Test
-        void shouldDefaultContextToEmptyMap() {
-            HensuSnapshot snapshot =
-                    new HensuSnapshot(
-                            "workflow-1",
-                            "exec-1",
-                            "node-1",
-                            null,
-                            new ExecutionHistory(),
-                            null,
-                            Instant.now(),
-                            null);
-
-            assertThat(snapshot.context()).isNotNull().isEmpty();
-        }
-
-        @Test
-        void shouldDefaultHistoryToEmptyHistory() {
-            HensuSnapshot snapshot =
-                    new HensuSnapshot(
-                            "workflow-1",
-                            "exec-1",
-                            "node-1",
-                            Map.of(),
-                            null,
-                            null,
-                            Instant.now(),
-                            null);
-
-            assertThat(snapshot.history()).isNotNull();
-            assertThat(snapshot.history().getSteps()).isEmpty();
-        }
-
-        @Test
-        void shouldDefaultCreatedAtToNow() {
-            Instant before = Instant.now();
-            HensuSnapshot snapshot =
-                    new HensuSnapshot(
-                            "workflow-1",
-                            "exec-1",
-                            "node-1",
-                            Map.of(),
-                            new ExecutionHistory(),
-                            null,
-                            null,
-                            null);
-            Instant after = Instant.now();
-
-            assertThat(snapshot.createdAt()).isNotNull();
-            assertThat(snapshot.createdAt()).isBetween(before, after.plusMillis(1));
-        }
-
-        @Test
-        void shouldMakeDefensiveCopyOfContext() {
-            Map<String, Object> originalContext = new java.util.HashMap<>();
-            originalContext.put("key", "value");
-
-            HensuSnapshot snapshot =
-                    new HensuSnapshot(
-                            "workflow-1",
-                            "exec-1",
-                            "node-1",
-                            originalContext,
-                            new ExecutionHistory(),
-                            null,
-                            Instant.now(),
-                            null);
-
-            originalContext.put("newKey", "newValue");
-
-            assertThat(snapshot.context()).doesNotContainKey("newKey");
-        }
+    @Test
+    void shouldRejectNullWorkflowId() {
+        assertThatThrownBy(
+                        () ->
+                                new HensuSnapshot(
+                                        null,
+                                        "exec-1",
+                                        "node-1",
+                                        Map.of(),
+                                        new ExecutionHistory(),
+                                        null,
+                                        Instant.now(),
+                                        null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("workflowId");
     }
 
-    @Nested
-    class StaticFactoryMethods {
+    @Test
+    void shouldMakeDefensiveCopyOfContext() {
+        Map<String, Object> originalContext = new HashMap<>();
+        originalContext.put("key", "value");
 
-        @Test
-        void shouldCreateFromStateWithoutReason() {
-            HensuState state = createTestState();
-            HensuSnapshot snapshot = HensuSnapshot.from(state);
+        HensuSnapshot snapshot =
+                new HensuSnapshot(
+                        "workflow-1",
+                        "exec-1",
+                        "node-1",
+                        originalContext,
+                        new ExecutionHistory(),
+                        null,
+                        Instant.now(),
+                        null);
 
-            assertThat(snapshot.workflowId()).isEqualTo("workflow-1");
-            assertThat(snapshot.executionId()).isEqualTo("exec-1");
-            assertThat(snapshot.currentNodeId()).isEqualTo("start");
-            assertThat(snapshot.checkpointReason()).isNull();
-        }
+        originalContext.put("newKey", "newValue");
 
-        @Test
-        void shouldCreateFromStateWithReason() {
-            HensuState state = createTestState();
-            HensuSnapshot snapshot = HensuSnapshot.from(state, "user-pause");
-
-            assertThat(snapshot.checkpointReason()).isEqualTo("user-pause");
-        }
-
-        @Test
-        void shouldCreateFromStateWithPlanSnapshot() {
-            HensuState state = createTestState();
-            PlanSnapshot planSnapshot = PlanSnapshot.empty("node-1");
-
-            HensuSnapshot snapshot = HensuSnapshot.from(state, planSnapshot, "plan-checkpoint");
-
-            assertThat(snapshot.hasActivePlan()).isTrue();
-            assertThat(snapshot.activePlan()).isSameAs(planSnapshot);
-            assertThat(snapshot.checkpointReason()).isEqualTo("plan-checkpoint");
-        }
-
-        @Test
-        void shouldThrowWhenStateIsNull() {
-            assertThatThrownBy(() -> HensuSnapshot.from(null))
-                    .isInstanceOf(NullPointerException.class);
-        }
-
-        @Test
-        void shouldThrowWhenPlanSnapshotIsNullInOverload() {
-            HensuState state = createTestState();
-            assertThatThrownBy(() -> HensuSnapshot.from(state, null, "reason"))
-                    .isInstanceOf(NullPointerException.class);
-        }
+        assertThat(snapshot.context()).doesNotContainKey("newKey");
     }
 
-    @Nested
-    class StateRestoration {
+    @Test
+    void shouldRestoreStateWithMutableCollections() {
+        // Regression: toState() must produce mutable context/history for resumed execution.
+        // List.copyOf() / Map.copyOf() broke mutation during resumed workflow runs.
+        HensuSnapshot snapshot =
+                new HensuSnapshot(
+                        "workflow-1",
+                        "exec-1",
+                        "current-node",
+                        Map.of("key", "value"),
+                        new ExecutionHistory(),
+                        null,
+                        Instant.now(),
+                        "test-checkpoint");
 
-        @Test
-        void shouldRestoreStateFromSnapshot() {
-            HensuSnapshot snapshot =
-                    new HensuSnapshot(
-                            "workflow-1",
-                            "exec-1",
-                            "current-node",
-                            Map.of("key", "value"),
-                            new ExecutionHistory(),
-                            null,
-                            Instant.now(),
-                            "test-checkpoint");
+        HensuState restored = snapshot.toState();
 
-            HensuState restored = snapshot.toState();
+        assertThat(restored.getWorkflowId()).isEqualTo("workflow-1");
+        assertThat(restored.getCurrentNode()).isEqualTo("current-node");
+        assertThat(restored.getContext()).containsEntry("key", "value");
 
-            assertThat(restored.getWorkflowId()).isEqualTo("workflow-1");
-            assertThat(restored.getExecutionId()).isEqualTo("exec-1");
-            assertThat(restored.getCurrentNode()).isEqualTo("current-node");
-            assertThat(restored.getContext()).containsEntry("key", "value");
-        }
+        // The restored context must be mutable for the executor to write into
+        restored.getContext().put("new_key", "new_value");
+        assertThat(restored.getContext()).containsEntry("new_key", "new_value");
     }
 
-    @Nested
-    class QueryMethods {
+    @Test
+    void shouldTreatNullCurrentNodeAsCompleted() {
+        HensuSnapshot snapshot =
+                new HensuSnapshot(
+                        "workflow-1",
+                        "exec-1",
+                        null,
+                        Map.of(),
+                        new ExecutionHistory(),
+                        null,
+                        Instant.now(),
+                        null);
 
-        @Test
-        void shouldDetectActivePlan() {
-            PlanSnapshot planSnapshot = PlanSnapshot.empty("node-1");
-            HensuSnapshot withPlan =
-                    new HensuSnapshot(
-                            "workflow-1",
-                            "exec-1",
-                            "node-1",
-                            Map.of(),
-                            new ExecutionHistory(),
-                            planSnapshot,
-                            Instant.now(),
-                            null);
-
-            HensuSnapshot withoutPlan =
-                    new HensuSnapshot(
-                            "workflow-1",
-                            "exec-1",
-                            "node-1",
-                            Map.of(),
-                            new ExecutionHistory(),
-                            null,
-                            Instant.now(),
-                            null);
-
-            assertThat(withPlan.hasActivePlan()).isTrue();
-            assertThat(withoutPlan.hasActivePlan()).isFalse();
-        }
-
-        @Test
-        void shouldDetectCompletedState() {
-            HensuSnapshot completed =
-                    new HensuSnapshot(
-                            "workflow-1",
-                            "exec-1",
-                            null,
-                            Map.of(),
-                            new ExecutionHistory(),
-                            null,
-                            Instant.now(),
-                            null);
-
-            HensuSnapshot inProgress =
-                    new HensuSnapshot(
-                            "workflow-1",
-                            "exec-1",
-                            "node-1",
-                            Map.of(),
-                            new ExecutionHistory(),
-                            null,
-                            Instant.now(),
-                            null);
-
-            assertThat(completed.isCompleted()).isTrue();
-            assertThat(inProgress.isCompleted()).isFalse();
-        }
-    }
-
-    private static HensuState createTestState() {
-        return new HensuState.Builder()
-                .executionId("exec-1")
-                .workflowId("workflow-1")
-                .currentNode("start")
-                .context(Map.of("input", "test"))
-                .history(new ExecutionHistory())
-                .build();
+        assertThat(snapshot.isCompleted()).isTrue();
+        assertThat(snapshot.currentNodeId()).isNull();
     }
 }

--- a/hensu-core/src/test/java/io/hensu/core/state/InMemoryWorkflowStateRepositoryTest.java
+++ b/hensu-core/src/test/java/io/hensu/core/state/InMemoryWorkflowStateRepositoryTest.java
@@ -1,14 +1,11 @@
 package io.hensu.core.state;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class InMemoryWorkflowStateRepositoryTest {
@@ -26,285 +23,72 @@ class InMemoryWorkflowStateRepositoryTest {
                 workflowId, executionId, currentNodeId, Map.of(), null, null, Instant.now(), null);
     }
 
-    @Nested
-    class Save {
+    @Test
+    void shouldOverwriteSnapshotOnSameExecution() {
+        repository.save("tenant-1", createSnapshot("wf-1", "exec-1", "node-1"));
+        repository.save("tenant-1", createSnapshot("wf-1", "exec-1", "node-2"));
 
-        @Test
-        void shouldSaveSnapshot() {
-            HensuSnapshot snapshot = createSnapshot("wf-1", "exec-1", "node-1");
-
-            repository.save("tenant-1", snapshot);
-
-            assertThat(repository.countForTenant("tenant-1")).isEqualTo(1);
-        }
-
-        @Test
-        void shouldUpdateExistingSnapshot() {
-            HensuSnapshot snapshot1 = createSnapshot("wf-1", "exec-1", "node-1");
-            HensuSnapshot snapshot2 = createSnapshot("wf-1", "exec-1", "node-2");
-
-            repository.save("tenant-1", snapshot1);
-            repository.save("tenant-1", snapshot2);
-
-            Optional<HensuSnapshot> found = repository.findByExecutionId("tenant-1", "exec-1");
-            assertThat(found).isPresent();
-            assertThat(found.get().currentNodeId()).isEqualTo("node-2");
-        }
-
-        @Test
-        void shouldIsolateTenants() {
-            HensuSnapshot snapshot1 = createSnapshot("wf-1", "exec-1", "node-1");
-            HensuSnapshot snapshot2 = createSnapshot("wf-1", "exec-1", "node-2");
-
-            repository.save("tenant-1", snapshot1);
-            repository.save("tenant-2", snapshot2);
-
-            assertThat(
-                            repository
-                                    .findByExecutionId("tenant-1", "exec-1")
-                                    .orElseThrow()
-                                    .currentNodeId())
-                    .isEqualTo("node-1");
-            assertThat(
-                            repository
-                                    .findByExecutionId("tenant-2", "exec-1")
-                                    .orElseThrow()
-                                    .currentNodeId())
-                    .isEqualTo("node-2");
-        }
-
-        @Test
-        void shouldRejectNullTenantId() {
-            HensuSnapshot snapshot = createSnapshot("wf-1", "exec-1", "node-1");
-
-            assertThatThrownBy(() -> repository.save(null, snapshot))
-                    .isInstanceOf(NullPointerException.class)
-                    .hasMessageContaining("tenantId");
-        }
-
-        @Test
-        void shouldRejectNullSnapshot() {
-            assertThatThrownBy(() -> repository.save("tenant-1", null))
-                    .isInstanceOf(NullPointerException.class)
-                    .hasMessageContaining("snapshot");
-        }
+        var found = repository.findByExecutionId("tenant-1", "exec-1");
+        assertThat(found).isPresent();
+        assertThat(found.get().currentNodeId()).isEqualTo("node-2");
+        assertThat(repository.countForTenant("tenant-1")).isEqualTo(1);
     }
 
-    @Nested
-    class FindByExecutionId {
+    @Test
+    void shouldIsolateTenantData() {
+        repository.save("tenant-1", createSnapshot("wf-1", "exec-1", "node-1"));
+        repository.save("tenant-2", createSnapshot("wf-1", "exec-1", "node-2"));
 
-        @Test
-        void shouldFindExistingSnapshot() {
-            HensuSnapshot snapshot = createSnapshot("wf-1", "exec-1", "node-1");
-            repository.save("tenant-1", snapshot);
+        // Same executionId, different tenants – must not cross-contaminate
+        assertThat(repository.findByExecutionId("tenant-1", "exec-1").orElseThrow().currentNodeId())
+                .isEqualTo("node-1");
+        assertThat(repository.findByExecutionId("tenant-2", "exec-1").orElseThrow().currentNodeId())
+                .isEqualTo("node-2");
 
-            Optional<HensuSnapshot> found = repository.findByExecutionId("tenant-1", "exec-1");
-
-            assertThat(found).isPresent();
-            assertThat(found.get().executionId()).isEqualTo("exec-1");
-        }
-
-        @Test
-        void shouldReturnEmptyForNonExistent() {
-            Optional<HensuSnapshot> found = repository.findByExecutionId("tenant-1", "exec-1");
-
-            assertThat(found).isEmpty();
-        }
-
-        @Test
-        void shouldReturnEmptyForWrongTenant() {
-            HensuSnapshot snapshot = createSnapshot("wf-1", "exec-1", "node-1");
-            repository.save("tenant-1", snapshot);
-
-            Optional<HensuSnapshot> found = repository.findByExecutionId("tenant-2", "exec-1");
-
-            assertThat(found).isEmpty();
-        }
-
-        @Test
-        void shouldRejectNullTenantId() {
-            assertThatThrownBy(() -> repository.findByExecutionId(null, "exec-1"))
-                    .isInstanceOf(NullPointerException.class)
-                    .hasMessageContaining("tenantId");
-        }
-
-        @Test
-        void shouldRejectNullExecutionId() {
-            assertThatThrownBy(() -> repository.findByExecutionId("tenant-1", null))
-                    .isInstanceOf(NullPointerException.class)
-                    .hasMessageContaining("executionId");
-        }
+        // Delete from tenant-2 must not affect tenant-1
+        repository.delete("tenant-2", "exec-1");
+        assertThat(repository.findByExecutionId("tenant-1", "exec-1")).isPresent();
+        assertThat(repository.findByExecutionId("tenant-2", "exec-1")).isEmpty();
     }
 
-    @Nested
-    class FindPaused {
+    @Test
+    void shouldFilterPausedFromCompleted() {
+        repository.save("tenant-1", createSnapshot("wf-1", "exec-1", "node-1"));
+        repository.save("tenant-1", createSnapshot("wf-1", "exec-2", null)); // completed
+        repository.save("tenant-1", createSnapshot("wf-1", "exec-3", "node-2"));
 
-        @Test
-        void shouldFindPausedSnapshots() {
-            repository.save("tenant-1", createSnapshot("wf-1", "exec-1", "node-1"));
-            repository.save("tenant-1", createSnapshot("wf-1", "exec-2", null)); // completed
-            repository.save("tenant-1", createSnapshot("wf-1", "exec-3", "node-2"));
+        List<HensuSnapshot> paused = repository.findPaused("tenant-1");
 
-            List<HensuSnapshot> paused = repository.findPaused("tenant-1");
-
-            assertThat(paused).hasSize(2);
-            assertThat(paused)
-                    .extracting(HensuSnapshot::executionId)
-                    .containsExactlyInAnyOrder("exec-1", "exec-3");
-        }
-
-        @Test
-        void shouldReturnEmptyForNoSnapshots() {
-            List<HensuSnapshot> paused = repository.findPaused("tenant-1");
-
-            assertThat(paused).isEmpty();
-        }
-
-        @Test
-        void shouldReturnEmptyWhenAllCompleted() {
-            repository.save("tenant-1", createSnapshot("wf-1", "exec-1", null));
-            repository.save("tenant-1", createSnapshot("wf-1", "exec-2", null));
-
-            List<HensuSnapshot> paused = repository.findPaused("tenant-1");
-
-            assertThat(paused).isEmpty();
-        }
-
-        @Test
-        void shouldRejectNullTenantId() {
-            assertThatThrownBy(() -> repository.findPaused(null))
-                    .isInstanceOf(NullPointerException.class)
-                    .hasMessageContaining("tenantId");
-        }
+        assertThat(paused).hasSize(2);
+        assertThat(paused)
+                .extracting(HensuSnapshot::executionId)
+                .containsExactlyInAnyOrder("exec-1", "exec-3");
     }
 
-    @Nested
-    class FindByWorkflowId {
+    @Test
+    void shouldDeleteAllForTenantWithoutAffectingOthers() {
+        repository.save("tenant-1", createSnapshot("wf-1", "exec-1", "node-1"));
+        repository.save("tenant-1", createSnapshot("wf-1", "exec-2", "node-2"));
+        repository.save("tenant-2", createSnapshot("wf-1", "exec-3", "node-1"));
 
-        @Test
-        void shouldFindByWorkflowId() {
-            repository.save("tenant-1", createSnapshot("wf-1", "exec-1", "node-1"));
-            repository.save("tenant-1", createSnapshot("wf-1", "exec-2", "node-2"));
-            repository.save("tenant-1", createSnapshot("wf-2", "exec-3", "node-1"));
+        int deleted = repository.deleteAllForTenant("tenant-1");
 
-            List<HensuSnapshot> found = repository.findByWorkflowId("tenant-1", "wf-1");
-
-            assertThat(found).hasSize(2);
-            assertThat(found)
-                    .extracting(HensuSnapshot::executionId)
-                    .containsExactlyInAnyOrder("exec-1", "exec-2");
-        }
-
-        @Test
-        void shouldReturnEmptyForNonExistentWorkflow() {
-            List<HensuSnapshot> found = repository.findByWorkflowId("tenant-1", "wf-1");
-
-            assertThat(found).isEmpty();
-        }
-
-        @Test
-        void shouldRejectNullTenantId() {
-            assertThatThrownBy(() -> repository.findByWorkflowId(null, "wf-1"))
-                    .isInstanceOf(NullPointerException.class)
-                    .hasMessageContaining("tenantId");
-        }
-
-        @Test
-        void shouldRejectNullWorkflowId() {
-            assertThatThrownBy(() -> repository.findByWorkflowId("tenant-1", null))
-                    .isInstanceOf(NullPointerException.class)
-                    .hasMessageContaining("workflowId");
-        }
+        assertThat(deleted).isEqualTo(2);
+        assertThat(repository.countForTenant("tenant-1")).isZero();
+        assertThat(repository.countForTenant("tenant-2")).isEqualTo(1);
     }
 
-    @Nested
-    class Delete {
+    @Test
+    void shouldFindByWorkflowIdAcrossExecutions() {
+        repository.save("tenant-1", createSnapshot("wf-1", "exec-1", "node-1"));
+        repository.save("tenant-1", createSnapshot("wf-1", "exec-2", "node-2"));
+        repository.save("tenant-1", createSnapshot("wf-2", "exec-3", "node-1"));
 
-        @Test
-        void shouldDeleteSnapshot() {
-            repository.save("tenant-1", createSnapshot("wf-1", "exec-1", "node-1"));
+        List<HensuSnapshot> found = repository.findByWorkflowId("tenant-1", "wf-1");
 
-            boolean deleted = repository.delete("tenant-1", "exec-1");
-
-            assertThat(deleted).isTrue();
-            assertThat(repository.findByExecutionId("tenant-1", "exec-1")).isEmpty();
-        }
-
-        @Test
-        void shouldReturnFalseForNonExistent() {
-            boolean deleted = repository.delete("tenant-1", "exec-1");
-
-            assertThat(deleted).isFalse();
-        }
-
-        @Test
-        void shouldNotDeleteFromOtherTenant() {
-            repository.save("tenant-1", createSnapshot("wf-1", "exec-1", "node-1"));
-
-            boolean deleted = repository.delete("tenant-2", "exec-1");
-
-            assertThat(deleted).isFalse();
-            assertThat(repository.findByExecutionId("tenant-1", "exec-1")).isPresent();
-        }
-
-        @Test
-        void shouldRejectNullTenantId() {
-            assertThatThrownBy(() -> repository.delete(null, "exec-1"))
-                    .isInstanceOf(NullPointerException.class)
-                    .hasMessageContaining("tenantId");
-        }
-
-        @Test
-        void shouldRejectNullExecutionId() {
-            assertThatThrownBy(() -> repository.delete("tenant-1", null))
-                    .isInstanceOf(NullPointerException.class)
-                    .hasMessageContaining("executionId");
-        }
-    }
-
-    @Nested
-    class DeleteAllForTenant {
-
-        @Test
-        void shouldDeleteAllForTenant() {
-            repository.save("tenant-1", createSnapshot("wf-1", "exec-1", "node-1"));
-            repository.save("tenant-1", createSnapshot("wf-1", "exec-2", "node-2"));
-            repository.save("tenant-2", createSnapshot("wf-1", "exec-3", "node-1"));
-
-            int deleted = repository.deleteAllForTenant("tenant-1");
-
-            assertThat(deleted).isEqualTo(2);
-            assertThat(repository.countForTenant("tenant-1")).isZero();
-            assertThat(repository.countForTenant("tenant-2")).isEqualTo(1);
-        }
-
-        @Test
-        void shouldReturnZeroForNonExistentTenant() {
-            int deleted = repository.deleteAllForTenant("tenant-1");
-
-            assertThat(deleted).isZero();
-        }
-
-        @Test
-        void shouldRejectNullTenantId() {
-            assertThatThrownBy(() -> repository.deleteAllForTenant(null))
-                    .isInstanceOf(NullPointerException.class)
-                    .hasMessageContaining("tenantId");
-        }
-    }
-
-    @Nested
-    class Clear {
-
-        @Test
-        void shouldClearAllData() {
-            repository.save("tenant-1", createSnapshot("wf-1", "exec-1", "node-1"));
-            repository.save("tenant-2", createSnapshot("wf-1", "exec-2", "node-1"));
-
-            repository.clear();
-
-            assertThat(repository.countForTenant("tenant-1")).isZero();
-            assertThat(repository.countForTenant("tenant-2")).isZero();
-        }
+        assertThat(found).hasSize(2);
+        assertThat(found)
+                .extracting(HensuSnapshot::executionId)
+                .containsExactlyInAnyOrder("exec-1", "exec-2");
     }
 }

--- a/hensu-core/src/test/java/io/hensu/core/tool/DefaultToolRegistryTest.java
+++ b/hensu-core/src/test/java/io/hensu/core/tool/DefaultToolRegistryTest.java
@@ -4,9 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class DefaultToolRegistryTest {
@@ -18,165 +16,31 @@ class DefaultToolRegistryTest {
         registry = new DefaultToolRegistry();
     }
 
-    @Nested
-    class Registration {
-
-        @Test
-        void shouldRegisterTool() {
-            ToolDefinition tool = ToolDefinition.simple("search", "Search tool");
-
-            registry.register(tool);
-
-            assertThat(registry.contains("search")).isTrue();
-            assertThat(registry.get("search")).hasValue(tool);
-        }
-
-        @Test
-        void shouldReplaceExistingTool() {
-            ToolDefinition original = ToolDefinition.simple("search", "Original");
-            ToolDefinition replacement = ToolDefinition.simple("search", "Replacement");
-
-            registry.register(original);
-            registry.register(replacement);
-
-            assertThat(registry.get("search"))
-                    .hasValueSatisfying(t -> assertThat(t.description()).isEqualTo("Replacement"));
-            assertThat(registry.size()).isEqualTo(1);
-        }
-
-        @Test
-        void shouldThrowWhenToolIsNull() {
-            assertThatThrownBy(() -> registry.register(null))
-                    .isInstanceOf(NullPointerException.class);
-        }
+    @Test
+    void shouldRejectNullToolRegistration() {
+        assertThatThrownBy(() -> registry.register(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("tool");
     }
 
-    @Nested
-    class Retrieval {
+    @Test
+    void shouldReturnDefensiveCopyFromAll() {
+        registry.register(ToolDefinition.simple("tool", "Tool"));
 
-        @Test
-        void shouldReturnEmptyWhenToolNotFound() {
-            Optional<ToolDefinition> result = registry.get("nonexistent");
+        List<ToolDefinition> snapshot = registry.all();
 
-            assertThat(result).isEmpty();
-        }
-
-        @Test
-        void shouldThrowWhenGetNameIsNull() {
-            assertThatThrownBy(() -> registry.get(null)).isInstanceOf(NullPointerException.class);
-        }
-
-        @Test
-        void shouldReturnAllTools() {
-            registry.register(ToolDefinition.simple("tool1", "Tool 1"));
-            registry.register(ToolDefinition.simple("tool2", "Tool 2"));
-            registry.register(ToolDefinition.simple("tool3", "Tool 3"));
-
-            List<ToolDefinition> all = registry.all();
-
-            assertThat(all).hasSize(3);
-            assertThat(all.stream().map(ToolDefinition::name))
-                    .containsExactlyInAnyOrder("tool1", "tool2", "tool3");
-        }
-
-        @Test
-        void shouldReturnImmutableListFromAll() {
-            registry.register(ToolDefinition.simple("tool", "Tool"));
-
-            List<ToolDefinition> all = registry.all();
-
-            assertThatThrownBy(() -> all.add(ToolDefinition.simple("new", "New")))
-                    .isInstanceOf(UnsupportedOperationException.class);
-        }
+        // Subsequent registry mutations must not alter a previously returned snapshot
+        registry.register(ToolDefinition.simple("tool2", "Tool 2"));
+        assertThat(snapshot).hasSize(1);
     }
 
-    @Nested
-    class Removal {
+    @Test
+    void shouldReplaceToolWithSameName() {
+        registry.register(ToolDefinition.simple("search", "Original"));
+        registry.register(ToolDefinition.simple("search", "Replacement"));
 
-        @Test
-        void shouldRemoveTool() {
-            registry.register(ToolDefinition.simple("tool", "Tool"));
-
-            boolean removed = registry.remove("tool");
-
-            assertThat(removed).isTrue();
-            assertThat(registry.contains("tool")).isFalse();
-        }
-
-        @Test
-        void shouldReturnFalseWhenRemovingNonexistent() {
-            boolean removed = registry.remove("nonexistent");
-
-            assertThat(removed).isFalse();
-        }
-
-        @Test
-        void shouldThrowWhenRemoveNameIsNull() {
-            assertThatThrownBy(() -> registry.remove(null))
-                    .isInstanceOf(NullPointerException.class);
-        }
-    }
-
-    @Nested
-    class Contains {
-
-        @Test
-        void shouldReturnTrueForRegisteredTool() {
-            registry.register(ToolDefinition.simple("tool", "Tool"));
-
-            assertThat(registry.contains("tool")).isTrue();
-        }
-
-        @Test
-        void shouldReturnFalseForUnregisteredTool() {
-            assertThat(registry.contains("nonexistent")).isFalse();
-        }
-
-        @Test
-        void shouldThrowWhenContainsNameIsNull() {
-            assertThatThrownBy(() -> registry.contains(null))
-                    .isInstanceOf(NullPointerException.class);
-        }
-    }
-
-    @Nested
-    class Size {
-
-        @Test
-        void shouldReturnZeroForEmptyRegistry() {
-            assertThat(registry.size()).isZero();
-        }
-
-        @Test
-        void shouldReturnCorrectSize() {
-            registry.register(ToolDefinition.simple("tool1", "Tool 1"));
-            registry.register(ToolDefinition.simple("tool2", "Tool 2"));
-
-            assertThat(registry.size()).isEqualTo(2);
-        }
-    }
-
-    @Nested
-    class InitialTools {
-
-        @Test
-        void shouldCreateWithInitialTools() {
-            List<ToolDefinition> initial =
-                    List.of(
-                            ToolDefinition.simple("tool1", "Tool 1"),
-                            ToolDefinition.simple("tool2", "Tool 2"));
-
-            DefaultToolRegistry registryWithInitial = new DefaultToolRegistry(initial);
-
-            assertThat(registryWithInitial.size()).isEqualTo(2);
-            assertThat(registryWithInitial.contains("tool1")).isTrue();
-            assertThat(registryWithInitial.contains("tool2")).isTrue();
-        }
-
-        @Test
-        void shouldThrowWhenInitialToolsIsNull() {
-            assertThatThrownBy(() -> new DefaultToolRegistry(null))
-                    .isInstanceOf(NullPointerException.class);
-        }
+        assertThat(registry.size()).isEqualTo(1);
+        assertThat(registry.get("search"))
+                .hasValueSatisfying(t -> assertThat(t.description()).isEqualTo("Replacement"));
     }
 }

--- a/hensu-core/src/test/java/io/hensu/core/util/AgentOutputValidatorTest.java
+++ b/hensu-core/src/test/java/io/hensu/core/util/AgentOutputValidatorTest.java
@@ -29,7 +29,8 @@ class AgentOutputValidatorTest {
 
     @ParameterizedTest(name = "rejected control char: U+{0}")
     @MethodSource("dangerousControlChars")
-    // label is consumed by JUnit 5 @ParameterizedTest(name=) for test display names, not by method body
+    // label is consumed by JUnit 5 @ParameterizedTest(name=) for test display names, not by method
+    // body
     void shouldRejectDangerousControlChars(@SuppressWarnings("unused") String label, String input) {
         assertThat(AgentOutputValidator.containsDangerousChars(input)).isTrue();
     }
@@ -56,20 +57,21 @@ class AgentOutputValidatorTest {
 
     @ParameterizedTest(name = "rejected Unicode trick: U+{0}")
     @MethodSource("dangerousUnicodeTricks")
-    // label is consumed by JUnit 5 @ParameterizedTest(name=) for test display names, not by method body
+    // label is consumed by JUnit 5 @ParameterizedTest(name=) for test display names, not by method
+    // body
     void shouldRejectUnicodeTricks(@SuppressWarnings("unused") String label, String input) {
         assertThat(AgentOutputValidator.containsUnicodeTricks(input)).isTrue();
     }
 
-    static Stream<org.junit.jupiter.params.provider.Arguments> dangerousUnicodeTricks() {
+    static Stream<Arguments> dangerousUnicodeTricks() {
         return Stream.of(
-                org.junit.jupiter.params.provider.Arguments.of("202A LRE", "text\u202Amore"),
-                org.junit.jupiter.params.provider.Arguments.of("202E RLO", "benign\u202Evil"),
-                org.junit.jupiter.params.provider.Arguments.of("2066 LRI", "text\u2066isolated"),
-                org.junit.jupiter.params.provider.Arguments.of("2069 PDI", "text\u2069end"),
-                org.junit.jupiter.params.provider.Arguments.of("200B ZWSP", "zero\u200Bwidth"),
-                org.junit.jupiter.params.provider.Arguments.of("200D ZWJ", "zero\u200Djoiner"),
-                org.junit.jupiter.params.provider.Arguments.of("FEFF BOM", "\uFEFFprefixed"));
+                Arguments.of("202A LRE", "text\u202Amore"),
+                Arguments.of("202E RLO", "benign\u202Evil"),
+                Arguments.of("2066 LRI", "text\u2066isolated"),
+                Arguments.of("2069 PDI", "text\u2069end"),
+                Arguments.of("200B ZWSP", "zero\u200Bwidth"),
+                Arguments.of("200D ZWJ", "zero\u200Djoiner"),
+                Arguments.of("FEFF BOM", "\uFEFFprefixed"));
     }
 
     @Test

--- a/hensu-core/src/test/java/io/hensu/core/util/AgentOutputValidatorTest.java
+++ b/hensu-core/src/test/java/io/hensu/core/util/AgentOutputValidatorTest.java
@@ -2,164 +2,78 @@ package io.hensu.core.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayName("AgentOutputValidator")
 class AgentOutputValidatorTest {
 
-    // ——————————————————————————————————————————————————————
-    // containsDangerousChars
-    // ——————————————————————————————————————————————————————
+    // -- containsDangerousChars ------------------------------------------------
 
-    @Test
-    @DisplayName("TAB (0x09) is allowed — range \\x00-\\x08 must not accidentally include it")
-    void shouldAllowTab() {
-        assertThat(AgentOutputValidator.containsDangerousChars("column1\tcolumn2")).isFalse();
+    @ParameterizedTest(name = "allowed char: {0}")
+    @ValueSource(
+            strings = {
+                "column1\tcolumn2", // TAB (0x09)
+                "line1\nline2", // LF  (0x0A)
+                "line1\r\nline2", // CR  (0x0D)
+                "hello world" // SPACE (0x20)
+            })
+    void shouldAllowSafeWhitespace(String input) {
+        assertThat(AgentOutputValidator.containsDangerousChars(input)).isFalse();
+    }
+
+    @ParameterizedTest(name = "rejected control char: U+{0}")
+    @MethodSource("dangerousControlChars")
+    // label is consumed by JUnit 5 @ParameterizedTest(name=) for test display names, not by method body
+    void shouldRejectDangerousControlChars(@SuppressWarnings("unused") String label, String input) {
+        assertThat(AgentOutputValidator.containsDangerousChars(input)).isTrue();
+    }
+
+    static Stream<Arguments> dangerousControlChars() {
+        return Stream.of(
+                Arguments.of("0000 NUL", "before\u0000after"),
+                Arguments.of("0008 BS", "back\u0008space"),
+                Arguments.of("000B VT", "line\u000Bbreak"),
+                Arguments.of("000C FF", "page\u000Cbreak"),
+                Arguments.of("000E SO", "bad\u000Echar"),
+                Arguments.of("001F US", "bad\u001Fchar"),
+                Arguments.of("007F DEL", "del\u007Fchar"));
     }
 
     @Test
-    @DisplayName("LF (0x0A) is allowed — multiline LLM output is normal")
-    void shouldAllowLineFeed() {
-        assertThat(AgentOutputValidator.containsDangerousChars("line1\nline2\nline3")).isFalse();
-    }
-
-    @Test
-    @DisplayName("CR (0x0D) is allowed — Windows CRLF line endings permitted")
-    void shouldAllowCarriageReturn() {
-        assertThat(AgentOutputValidator.containsDangerousChars("line1\r\nline2")).isFalse();
-    }
-
-    @Test
-    @DisplayName("BS (0x08) is rejected — end boundary of first range \\x00-\\x08")
-    void shouldRejectBackspace() {
-        assertThat(AgentOutputValidator.containsDangerousChars("back\u0008space")).isTrue();
-    }
-
-    @Test
-    @DisplayName("VT (0x0B) is rejected — explicitly included between LF and FF")
-    void shouldRejectVerticalTab() {
-        assertThat(AgentOutputValidator.containsDangerousChars("line\u000Bbreak")).isTrue();
-    }
-
-    @Test
-    @DisplayName("FF (0x0C) is rejected — explicitly included between VT and CR")
-    void shouldRejectFormFeed() {
-        assertThat(AgentOutputValidator.containsDangerousChars("page\u000Cbreak")).isTrue();
-    }
-
-    @Test
-    @DisplayName("SO (0x0E) is rejected — start boundary of range \\x0E-\\x1F")
-    void shouldRejectShiftOut() {
-        assertThat(AgentOutputValidator.containsDangerousChars("bad\u000Echar")).isTrue();
-    }
-
-    @Test
-    @DisplayName("US (0x1F) is rejected — end boundary of range \\x0E-\\x1F")
-    void shouldRejectUnitSeparator() {
-        assertThat(AgentOutputValidator.containsDangerousChars("bad\u001Fchar")).isTrue();
-    }
-
-    @Test
-    @DisplayName("SPACE (0x20) is allowed — first printable ASCII char, pattern must not bleed up")
-    void shouldAllowSpace() {
-        assertThat(AgentOutputValidator.containsDangerousChars("hello world")).isFalse();
-    }
-
-    @Test
-    @DisplayName("DEL (0x7F) is rejected — singleton at upper ASCII boundary")
-    void shouldRejectDel() {
-        assertThat(AgentOutputValidator.containsDangerousChars("del\u007Fchar")).isTrue();
-    }
-
-    @Test
-    @DisplayName("0x80 is allowed — pattern must not bleed into extended ASCII / Latin-1")
-    void shouldAllowFirstExtendedAscii() {
-        assertThat(AgentOutputValidator.containsDangerousChars("\u0080extended")).isFalse();
-    }
-
-    @Test
-    @DisplayName(
-            "NUL byte (0x00) is rejected — classic injection and null-termination attack vector")
-    void shouldRejectNulByte() {
-        assertThat(AgentOutputValidator.containsDangerousChars("before\u0000after")).isTrue();
-    }
-
-    @Test
-    @DisplayName("control char buried deep in long string is detected regardless of position")
+    @DisplayName("control char buried deep in long string is detected")
     void shouldDetectControlCharEmbeddedInLongString() {
         String payload = "x".repeat(1000) + "\u0007" + "y".repeat(1000);
         assertThat(AgentOutputValidator.containsDangerousChars(payload)).isTrue();
     }
 
-    @Test
-    @DisplayName("null input returns false without throwing")
-    void shouldReturnFalseForNullDangerous() {
-        assertThat(AgentOutputValidator.containsDangerousChars(null)).isFalse();
+    // -- containsUnicodeTricks ------------------------------------------------
+
+    @ParameterizedTest(name = "rejected Unicode trick: U+{0}")
+    @MethodSource("dangerousUnicodeTricks")
+    // label is consumed by JUnit 5 @ParameterizedTest(name=) for test display names, not by method body
+    void shouldRejectUnicodeTricks(@SuppressWarnings("unused") String label, String input) {
+        assertThat(AgentOutputValidator.containsUnicodeTricks(input)).isTrue();
     }
 
-    // ——————————————————————————————————————————————————————
-    // containsUnicodeTricks
-    // ——————————————————————————————————————————————————————
-
-    @Test
-    @DisplayName("LRE (U+202A) is rejected — start of directional override range")
-    void shouldRejectLre() {
-        assertThat(AgentOutputValidator.containsUnicodeTricks("text\u202Amore")).isTrue();
-    }
-
-    @Test
-    @DisplayName(
-            "RLO (U+202E) is rejected — end of directional override range, classic hiding attack")
-    void shouldRejectRlo() {
-        assertThat(AgentOutputValidator.containsUnicodeTricks("benign\u202Evil")).isTrue();
+    static Stream<org.junit.jupiter.params.provider.Arguments> dangerousUnicodeTricks() {
+        return Stream.of(
+                org.junit.jupiter.params.provider.Arguments.of("202A LRE", "text\u202Amore"),
+                org.junit.jupiter.params.provider.Arguments.of("202E RLO", "benign\u202Evil"),
+                org.junit.jupiter.params.provider.Arguments.of("2066 LRI", "text\u2066isolated"),
+                org.junit.jupiter.params.provider.Arguments.of("2069 PDI", "text\u2069end"),
+                org.junit.jupiter.params.provider.Arguments.of("200B ZWSP", "zero\u200Bwidth"),
+                org.junit.jupiter.params.provider.Arguments.of("200D ZWJ", "zero\u200Djoiner"),
+                org.junit.jupiter.params.provider.Arguments.of("FEFF BOM", "\uFEFFprefixed"));
     }
 
     @Test
-    @DisplayName(
-            "U+202F (NARROW NO-BREAK SPACE) is allowed — char immediately after U+202E, range must not overshoot")
-    void shouldAllowNarrowNoBreakSpace() {
-        assertThat(AgentOutputValidator.containsUnicodeTricks("ok\u202Fspacing")).isFalse();
-    }
-
-    @Test
-    @DisplayName("LRI (U+2066) is rejected — start of Unicode isolate range")
-    void shouldRejectLri() {
-        assertThat(AgentOutputValidator.containsUnicodeTricks("text\u2066isolated")).isTrue();
-    }
-
-    @Test
-    @DisplayName("PDI (U+2069) is rejected — end of Unicode isolate range")
-    void shouldRejectPdi() {
-        assertThat(AgentOutputValidator.containsUnicodeTricks("text\u2069end")).isTrue();
-    }
-
-    @Test
-    @DisplayName("U+206A is allowed — char immediately after U+2069, range must not overshoot")
-    void shouldAllowCharJustAfterIsolateRange() {
-        assertThat(AgentOutputValidator.containsUnicodeTricks("ok\u206Atext")).isFalse();
-    }
-
-    @Test
-    @DisplayName("ZWSP (U+200B) is rejected — start of zero-width range, invisible spacing attack")
-    void shouldRejectZwsp() {
-        assertThat(AgentOutputValidator.containsUnicodeTricks("zero\u200Bwidth")).isTrue();
-    }
-
-    @Test
-    @DisplayName("ZWJ (U+200D) is rejected — end of zero-width range")
-    void shouldRejectZwj() {
-        assertThat(AgentOutputValidator.containsUnicodeTricks("zero\u200Djoiner")).isTrue();
-    }
-
-    @Test
-    @DisplayName("BOM (U+FEFF) is rejected — byte-order mark has no place in LLM text content")
-    void shouldRejectBom() {
-        assertThat(AgentOutputValidator.containsUnicodeTricks("\uFEFFprefixed content")).isTrue();
-    }
-
-    @Test
-    @DisplayName("legitimate Arabic text is allowed — RTL script must not produce false positives")
+    @DisplayName("legitimate Arabic text must not produce false positives")
     void shouldAllowLegitimateArabicText() {
         // "العربية" — natural RTL script, no directional override characters
         assertThat(
@@ -169,59 +83,40 @@ class AgentOutputValidatorTest {
     }
 
     @Test
-    @DisplayName("legitimate Hebrew text is allowed — another natural RTL script")
-    void shouldAllowLegitimateHebrewText() {
-        // "שלום" — natural RTL script
-        assertThat(AgentOutputValidator.containsUnicodeTricks("\u05E9\u05DC\u05D5\u05DD"))
-                .isFalse();
+    @DisplayName("range boundaries must not overshoot into safe chars")
+    void shouldNotOvershootRangeBoundaries() {
+        // U+202F (NARROW NO-BREAK SPACE) is immediately after U+202E
+        assertThat(AgentOutputValidator.containsUnicodeTricks("ok\u202Fspacing")).isFalse();
+        // U+206A is immediately after U+2069
+        assertThat(AgentOutputValidator.containsUnicodeTricks("ok\u206Atext")).isFalse();
+        // U+0080 is immediately after DEL
+        assertThat(AgentOutputValidator.containsDangerousChars("\u0080extended")).isFalse();
     }
 
-    @Test
-    @DisplayName("null input returns false without throwing")
-    void shouldReturnFalseForNullUnicode() {
-        assertThat(AgentOutputValidator.containsUnicodeTricks(null)).isFalse();
-    }
-
-    // ——————————————————————————————————————————————————————
-    // exceedsSizeLimit
-    // ——————————————————————————————————————————————————————
+    // -- exceedsSizeLimit -----------------------------------------------------
 
     @Test
-    @DisplayName(
-            "emoji (4 UTF-8 bytes) counted by byte length, not char length — catches length() vs getBytes() bug")
-    void shouldCountBytesNotCharLengthForEmoji() {
+    @DisplayName("byte length used, not char length — catches surrogate pair / multi-byte bugs")
+    void shouldCountBytesNotCharLength() {
         // U+1F600 GRINNING FACE: 4 bytes in UTF-8, but String.length() = 2 (surrogate pair)
         String emoji = "\uD83D\uDE00"; // 😀
-        assertThat(emoji).hasSize(2); // confirms the trap: char length is 2
+        assertThat(emoji).hasSize(2);
         assertThat(AgentOutputValidator.exceedsSizeLimit(emoji, 3)).isTrue();
         assertThat(AgentOutputValidator.exceedsSizeLimit(emoji, 4)).isFalse();
-    }
 
-    @Test
-    @DisplayName("3-byte UTF-8 char (€) counted correctly at boundary")
-    void shouldCountThreeByteCharsCorrectly() {
-        String euro = "\u20AC"; // € — 3 bytes in UTF-8
+        // € — 3 bytes in UTF-8, String.length() = 1
+        String euro = "\u20AC";
         assertThat(AgentOutputValidator.exceedsSizeLimit(euro, 2)).isTrue();
         assertThat(AgentOutputValidator.exceedsSizeLimit(euro, 3)).isFalse();
     }
 
-    @Test
-    @DisplayName("payload at exact byte limit is not rejected")
-    void shouldAllowPayloadAtExactLimit() {
-        String s = "abc"; // 3 ASCII bytes
-        assertThat(AgentOutputValidator.exceedsSizeLimit(s, 3)).isFalse();
-    }
+    // -- validate (integration) -----------------------------------------------
 
     @Test
-    @DisplayName("payload one byte over limit is rejected")
-    void shouldRejectPayloadOneByteOverLimit() {
-        String s = "abcd"; // 4 ASCII bytes
-        assertThat(AgentOutputValidator.exceedsSizeLimit(s, 3)).isTrue();
-    }
-
-    @Test
-    @DisplayName("null input returns false without throwing")
-    void shouldReturnFalseForNullSize() {
-        assertThat(AgentOutputValidator.exceedsSizeLimit(null, 100)).isFalse();
+    @DisplayName("validate returns violation reason for dangerous output")
+    void shouldReturnViolationForDangerousOutput() {
+        assertThat(AgentOutputValidator.validate("clean output")).isEmpty();
+        assertThat(AgentOutputValidator.validate("bad\u0000output")).isPresent();
+        assertThat(AgentOutputValidator.validate("bidi\u202Eattack")).isPresent();
     }
 }

--- a/hensu-core/src/test/java/io/hensu/core/workflow/transition/TransitionRulesTest.java
+++ b/hensu-core/src/test/java/io/hensu/core/workflow/transition/TransitionRulesTest.java
@@ -2,6 +2,7 @@ package io.hensu.core.workflow.transition;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.hensu.core.execution.EngineVariables;
 import io.hensu.core.execution.executor.NodeResult;
 import io.hensu.core.execution.result.ExecutionHistory;
 import io.hensu.core.rubric.model.ComparisonOperator;
@@ -119,7 +120,7 @@ class TransitionRulesTest {
                             new ScoreCondition(ComparisonOperator.LT, 80.0, null, "needs-review"));
             ScoreTransition transition = new ScoreTransition(conditions);
 
-            state.getContext().put("score", 85.0);
+            state.getContext().put(EngineVariables.SCORE, 85.0);
             NodeResult result = NodeResult.success("Output", Map.of());
 
             // When
@@ -138,7 +139,7 @@ class TransitionRulesTest {
                             new ScoreCondition(ComparisonOperator.LT, 80.0, null, "needs-review"));
             ScoreTransition transition = new ScoreTransition(conditions);
 
-            state.getContext().put("score", 65.0);
+            state.getContext().put(EngineVariables.SCORE, 65.0);
             NodeResult result = NodeResult.success("Output", Map.of());
 
             // When
@@ -173,7 +174,7 @@ class TransitionRulesTest {
             ScoreTransition transition = new ScoreTransition(conditions);
 
             // Set score in context (self-reported)
-            state.getContext().put("score", 90.0);
+            state.getContext().put(EngineVariables.SCORE, 90.0);
             NodeResult result = NodeResult.success("Output", Map.of());
 
             // When
@@ -191,7 +192,7 @@ class TransitionRulesTest {
             ScoreTransition transition = new ScoreTransition(conditions);
 
             // Set score as string
-            state.getContext().put("score", "85.5");
+            state.getContext().put(EngineVariables.SCORE, "85.5");
             NodeResult result = NodeResult.success("Output", Map.of());
 
             // When
@@ -208,7 +209,7 @@ class TransitionRulesTest {
                     List.of(new ScoreCondition(ComparisonOperator.GT, 90.0, null, "excellent"));
             ScoreTransition transition = new ScoreTransition(conditions);
 
-            state.getContext().put("score", 85.0);
+            state.getContext().put(EngineVariables.SCORE, 85.0);
             NodeResult result = NodeResult.success("Output", Map.of());
 
             String target = transition.evaluate(state, result);
@@ -232,7 +233,7 @@ class TransitionRulesTest {
                 })
         void shouldRouteByBooleanApprovalTruthTable(
                 boolean expected, boolean contextValue, String expectedTarget) {
-            state.getContext().put("approved", contextValue);
+            state.getContext().put(EngineVariables.APPROVED, contextValue);
             String targetNode = expected ? "finalize" : "improve";
             ApprovalTransition transition = new ApprovalTransition(expected, targetNode);
 
@@ -252,7 +253,7 @@ class TransitionRulesTest {
         @Test
         void shouldReturnNullForNonBooleanValue() {
             // Agent output an integer — strict parsing must fall through, never guess intent
-            state.getContext().put("approved", 1);
+            state.getContext().put(EngineVariables.APPROVED, 1);
             assertThat(
                             new ApprovalTransition(true, "finalize")
                                     .evaluate(state, NodeResult.success("Output", Map.of())))
@@ -262,7 +263,7 @@ class TransitionRulesTest {
         @Test
         void shouldReturnNullForAmbiguousStringValue() {
             // Agent output free-form text — strict parsing must reject it
-            state.getContext().put("approved", "looks good to me");
+            state.getContext().put(EngineVariables.APPROVED, "looks good to me");
             assertThat(
                             new ApprovalTransition(true, "finalize")
                                     .evaluate(state, NodeResult.success("Output", Map.of())))
@@ -281,7 +282,7 @@ class TransitionRulesTest {
         })
         void shouldAcceptBooleanStringsCaseInsensitively(
                 String contextValue, boolean expected, String expectedTarget) {
-            state.getContext().put("approved", contextValue);
+            state.getContext().put(EngineVariables.APPROVED, contextValue);
             assertThat(
                             new ApprovalTransition(expected, expectedTarget)
                                     .evaluate(state, NodeResult.success("Output", Map.of())))

--- a/hensu-dsl/README.md
+++ b/hensu-dsl/README.md
@@ -90,7 +90,7 @@ See [DSL Reference](../docs/dsl-reference.md) for the complete syntax reference 
 - Agent definitions and model constants
 - Node types (standard, parallel, fork/join, action, generic, end)
 - Transition rules (success, failure, score-based, approval, consensus)
-- State variables (`writes()` + `{placeholder}` syntax)
+- State variables (`writes()` + `{placeholder}` syntax), branch outputs (`yields()`)
 - State schema (`state { }` block with typed `input`/`variable` declarations and load-time validation)
 - Approval routing (`onApproval goto` / `onRejection goto`)
 - Plan failure routing (`onPlanFailure goto`)

--- a/hensu-dsl/src/main/kotlin/io/hensu/dsl/builders/ParallelNodeBuilder.kt
+++ b/hensu-dsl/src/main/kotlin/io/hensu/dsl/builders/ParallelNodeBuilder.kt
@@ -1,11 +1,13 @@
 package io.hensu.dsl.builders
 
+import io.hensu.core.execution.EngineVariables
 import io.hensu.core.execution.parallel.Branch
 import io.hensu.core.execution.parallel.ConsensusConfig
 import io.hensu.core.execution.parallel.ConsensusStrategy
 import io.hensu.core.workflow.node.ParallelNode
 import io.hensu.dsl.WorkingDirectory
 import io.hensu.dsl.extensions.resolveAsPrompt
+import java.util.logging.Logger
 
 /**
  * DSL builder for parallel nodes with consensus-based outcome evaluation.
@@ -45,6 +47,7 @@ import io.hensu.dsl.extensions.resolveAsPrompt
 @WorkflowDsl
 class ParallelNodeBuilder(private val id: String, private val workingDirectory: WorkingDirectory) :
     BaseNodeBuilder, ConsensusMarkers {
+    private val logger = Logger.getLogger(ParallelNodeBuilder::class.java.name)
     private val branches = mutableListOf<BranchBuilder>()
     private var consensusConfig: ConsensusConfig? = null
     private val transitionBuilder = TransitionBuilder()
@@ -128,6 +131,21 @@ class ParallelNodeBuilder(private val id: String, private val workingDirectory: 
 
         val builtBranches = branches.map { it.build() }
 
+        // Warn when consensus branches declare no yields – likely an author oversight.
+        // Pure go/no-go gating (no domain output) is valid but rare.
+        if (consensusConfig != null) {
+            builtBranches
+                .filter { it.yields.isEmpty() }
+                .forEach { branch ->
+                    logger.warning(
+                        "Parallel node '$id': branch '${branch.id}' participates in consensus " +
+                            "but declares no yields(). It will contribute no domain data to the " +
+                            "context after consensus. If this is intentional (pure vote), ignore " +
+                            "this warning."
+                    )
+                }
+        }
+
         return ParallelNode.builder(id)
             .branches(builtBranches)
             .consensus(consensusConfig)
@@ -162,6 +180,35 @@ class BranchBuilder(private val id: String, private val workingDirectory: Workin
     /** Weight for weighted voting consensus. Default: 1.0. */
     var weight: Double = 1.0
 
+    private val yieldFields = mutableListOf<String>()
+
+    /**
+     * Declares state variable names this branch produces as structured output.
+     *
+     * Yielded fields are extracted from the agent's JSON response by the processor pipeline and
+     * promoted to the parent context when the branch wins consensus.
+     *
+     * Example:
+     * ```kotlin
+     * branch("analyzer") {
+     *     agent = "api-analyst"
+     *     prompt = "Analyze the API: {spec}"
+     *     yields("api_schema", "summary")
+     * }
+     * ```
+     *
+     * @param fields state variable names to extract from agent output
+     */
+    fun yields(vararg fields: String) {
+        for (field in fields) {
+            require(!EngineVariables.isEngineVar(field)) {
+                "Branch '$id': yield field '$field' is a reserved engine variable. " +
+                    "Use a different name (e.g. 'review_$field')."
+            }
+        }
+        yieldFields.addAll(fields.toList())
+    }
+
     /**
      * Builds the [Branch] from this builder.
      *
@@ -175,6 +222,7 @@ class BranchBuilder(private val id: String, private val workingDirectory: Workin
             prompt.resolveAsPrompt(workingDirectory) ?: "",
             rubric,
             weight,
+            yieldFields,
         )
 }
 

--- a/hensu-dsl/src/main/kotlin/io/hensu/dsl/builders/StandardNodeBuilder.kt
+++ b/hensu-dsl/src/main/kotlin/io/hensu/dsl/builders/StandardNodeBuilder.kt
@@ -1,5 +1,6 @@
 package io.hensu.dsl.builders
 
+import io.hensu.core.execution.EngineVariables
 import io.hensu.core.plan.Plan
 import io.hensu.core.plan.PlanningConfig
 import io.hensu.core.review.ReviewConfig
@@ -101,6 +102,12 @@ class StandardNodeBuilder(private val id: String, private val workingDirectory: 
      * @param names variable names this node writes to
      */
     fun writes(vararg names: String) {
+        for (name in names) {
+            require(!EngineVariables.isEngineVar(name)) {
+                "Node '$id': writes field '$name' is a reserved engine variable. " +
+                    "Use a different name (e.g. 'review_$name')."
+            }
+        }
         writes = names.toList()
     }
 

--- a/hensu-dsl/src/test/kotlin/io/hensu/dsl/builders/NodeBuilderTest.kt
+++ b/hensu-dsl/src/test/kotlin/io/hensu/dsl/builders/NodeBuilderTest.kt
@@ -201,7 +201,6 @@ class NodeBuilderTest {
         val builder = StandardNodeBuilder("reviewer", workingDir)
         builder.apply {
             agent = "agent1"
-            writes("approved")
             onApproval goto "finalize"
             onRejection goto "improve"
         }
@@ -234,6 +233,20 @@ class NodeBuilderTest {
         // Then
         assertThat(node.agentId).isNull()
         assertThat(node.prompt).isEqualTo("Manual step")
+    }
+
+    @Test
+    fun `should reject writes that collide with engine variables`() {
+        val builder = StandardNodeBuilder("node1", workingDir)
+
+        assertThatThrownBy {
+                builder.apply {
+                    agent = "agent1"
+                    writes("score")
+                }
+            }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("reserved engine variable")
     }
 
     @Nested

--- a/hensu-dsl/src/test/kotlin/io/hensu/dsl/builders/ParallelNodeBuilderTest.kt
+++ b/hensu-dsl/src/test/kotlin/io/hensu/dsl/builders/ParallelNodeBuilderTest.kt
@@ -163,6 +163,23 @@ class ParallelNodeBuilderTest {
                 .isInstanceOf(IllegalStateException::class.java)
                 .hasMessageContaining("must have an agent")
         }
+
+        @Test
+        fun `should reject yields that collide with engine variables`() {
+            val builder = ParallelNodeBuilder("parallel-1", workingDir)
+
+            assertThatThrownBy {
+                    builder.apply {
+                        branch("b1") {
+                            agent = "reviewer"
+                            prompt = "Review"
+                            yields("score")
+                        }
+                    }
+                }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("reserved engine variable")
+        }
     }
 
     @Nested

--- a/hensu-serialization/README.md
+++ b/hensu-serialization/README.md
@@ -61,6 +61,29 @@ Builder mixins use `@JsonPOJOBuilder(withPrefix = "", buildMethodName = "build")
 the fluent builder API (e.g., `.nodeId("x")` not `.withNodeId("x")`).
 
 **`NodeResult.getError()`** is `@JsonIgnore`d because `Throwable` is not safely serializable.
+
+### Plain Records (Default Jackson Serialization)
+
+Java records with public component accessors are serialized by Jackson's default `BeanSerializer`
+without requiring custom serializers or mixins. However, in GraalVM native image, Jackson cannot
+discover record accessors unless they are registered for reflection.
+
+These types are deserialized manually in `NodeDeserializer` (direct `JsonNode` extraction), but
+serialized via default Jackson machinery in `WorkflowSerializer.toJson()`. Both paths must work:
+
+| Type                       | Context                                                            |
+|----------------------------|--------------------------------------------------------------------|
+| `Branch`                   | Embedded in `ParallelNode` – includes `yields` (List of String)    |
+| `ConsensusConfig`          | Embedded in `ParallelNode` – strategy, threshold, judge agent ID   |
+| `ConsensusStrategy`        | Enum inside `ConsensusConfig`                                      |
+| `ConsensusResult`          | Stored in state context during checkpoint serialization            |
+| `ConsensusResult.Vote`     | Inner record inside `ConsensusResult`                              |
+| `ConsensusResult.VoteType` | Enum inside `ConsensusResult.Vote`                                 |
+| `ScoreCondition`           | Embedded in `ScoreTransition` via `NodeDeserializer`               |
+| `DoubleRange`              | Embedded in `ScoreCondition`                                       |
+
+All are registered in `NativeImageConfig` in `hensu-server`. Do **not** create mixins for these –
+reflection registration is sufficient since they have public constructors and accessors.
 Errors are transient and not persisted in snapshots. The builder mixin (`NodeResultBuilderMixin`)
 also suppresses the `error(Throwable)` setter with `@JsonIgnore` — this prevents Jackson from
 crashing when deserializing a snapshot payload that contains no `error` field. Both halves of

--- a/hensu-serialization/src/main/java/io/hensu/serialization/NodeDeserializer.java
+++ b/hensu-serialization/src/main/java/io/hensu/serialization/NodeDeserializer.java
@@ -235,6 +235,10 @@ class NodeDeserializer extends StdDeserializer<Node> {
     private List<Branch> deserializeBranches(JsonNode array) {
         List<Branch> branches = new ArrayList<>();
         for (JsonNode b : array) {
+            List<String> yields =
+                    b.has("yields") && b.get("yields").isArray()
+                            ? readStringList(b.get("yields"))
+                            : List.of();
             branches.add(
                     new Branch(
                             b.get("id").asText(),
@@ -245,9 +249,18 @@ class NodeDeserializer extends StdDeserializer<Node> {
                             b.has("rubricId") && !b.get("rubricId").isNull()
                                     ? b.get("rubricId").asText()
                                     : null,
-                            b.has("weight") ? b.get("weight").doubleValue() : 1.0));
+                            b.has("weight") ? b.get("weight").doubleValue() : 1.0,
+                            yields));
         }
         return branches;
+    }
+
+    private List<String> readStringList(JsonNode array) {
+        List<String> result = new ArrayList<>();
+        for (JsonNode item : array) {
+            result.add(item.asText());
+        }
+        return result;
     }
 
     private String textOrNull(JsonNode root, String field) {

--- a/hensu-serialization/src/test/java/io/hensu/serialization/WorkflowSerializerTest.java
+++ b/hensu-serialization/src/test/java/io/hensu/serialization/WorkflowSerializerTest.java
@@ -155,7 +155,14 @@ class WorkflowSerializerTest {
         ParallelNode parallel =
                 ParallelNode.builder("parallel")
                         .branch(new Branch("b1", "writer", "prompt1", null))
-                        .branch(new Branch("b2", "reviewer", "prompt2", "rubric1", 2.0))
+                        .branch(
+                                new Branch(
+                                        "b2",
+                                        "reviewer",
+                                        "prompt2",
+                                        "rubric1",
+                                        2.0,
+                                        List.of("api_schema", "confidence")))
                         .consensus(
                                 new ConsensusConfig("judge", ConsensusStrategy.JUDGE_DECIDES, 0.8))
                         .transitionRules(List.of(new SuccessTransition("done")))
@@ -175,7 +182,10 @@ class WorkflowSerializerTest {
         ParallelNode restoredParallel = (ParallelNode) restored.getNodes().get("parallel");
         assertThat(restoredParallel.getBranchesList()).hasSize(2);
         assertThat(restoredParallel.getBranchesList().get(0).getWeight()).isEqualTo(1.0);
+        assertThat(restoredParallel.getBranchesList().get(0).getYields()).isEmpty();
         assertThat(restoredParallel.getBranchesList().get(1).getWeight()).isEqualTo(2.0);
+        assertThat(restoredParallel.getBranchesList().get(1).getYields())
+                .containsExactly("api_schema", "confidence");
         ConsensusConfig cc = restoredParallel.getConsensusConfig();
         assertThat(cc.strategy()).isEqualTo(ConsensusStrategy.JUDGE_DECIDES);
         assertThat(cc.judgeAgentId()).isEqualTo("judge");

--- a/hensu-server/src/main/java/io/hensu/server/config/NativeImageConfig.java
+++ b/hensu-server/src/main/java/io/hensu/server/config/NativeImageConfig.java
@@ -2,6 +2,10 @@ package io.hensu.server.config;
 
 import io.hensu.core.agent.AgentConfig;
 import io.hensu.core.execution.executor.NodeResult;
+import io.hensu.core.execution.parallel.Branch;
+import io.hensu.core.execution.parallel.ConsensusConfig;
+import io.hensu.core.execution.parallel.ConsensusResult;
+import io.hensu.core.execution.parallel.ConsensusStrategy;
 import io.hensu.core.execution.result.BacktrackEvent;
 import io.hensu.core.execution.result.ExecutionHistory;
 import io.hensu.core.execution.result.ExecutionStep;
@@ -11,6 +15,8 @@ import io.hensu.core.plan.PlanSnapshot;
 import io.hensu.core.plan.PlannedStep;
 import io.hensu.core.plan.PlanningConfig;
 import io.hensu.core.review.ReviewConfig;
+import io.hensu.core.rubric.model.DoubleRange;
+import io.hensu.core.rubric.model.ScoreCondition;
 import io.hensu.core.state.HensuSnapshot;
 import io.hensu.core.workflow.Workflow;
 import io.hensu.core.workflow.state.StateVariableDeclaration;
@@ -19,7 +25,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /// GraalVM native image reflection registrations for `hensu-core` domain model classes.
 ///
-/// Four patterns require explicit registration:
+/// Five patterns require explicit registration:
 ///
 /// ### 1. Jackson `@JsonPOJOBuilder` mixin pattern
 /// {@link io.hensu.serialization.HensuJacksonModule} maps each of these types to a builder mixin.
@@ -37,11 +43,16 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 /// `io.hensu.serialization.NodeDeserializer` delegates `PlanningConfig` and `Plan`
 /// deserialization to `mapper.treeToValue()` because their nested `Duration` / `PlannedStep`
 /// fields make manual `JsonNode` extraction error-prone. These types must be registered so
-/// Jackson's POJO reflection can reach their fields at runtime. Simple nested types
-/// (`ConsensusConfig`, `Branch`, `ScoreCondition`, `DoubleRange`) are extracted manually —
-/// no registration needed.
+/// Jackson's POJO reflection can reach their fields at runtime.
 ///
-/// ### 3. Serialization of simple immutable types
+/// ### 3. Nested types deserialized manually but serialized by default Jackson
+/// `NodeDeserializer` extracts `ConsensusConfig`, `Branch`, `ScoreCondition`, and
+/// `DoubleRange` manually via `JsonNode` – no reflection needed for deserialization.
+/// However, `WorkflowSerializer.toJson()` uses Jackson's default `BeanSerializer` for
+/// the entire `Workflow` graph, which reads record component accessors reflectively.
+/// All types reachable from `Workflow` must be registered for serialization to work.
+///
+/// ### 4. Serialization of simple immutable types
 /// `WorkflowStateSchema` uses a custom deserializer (`WorkflowStateSchemaDeserializer`) that
 /// extracts fields manually — no reflection required for deserialization. However, Jackson's
 /// default **serializer** still reads `getVariables()` reflectively, so both classes must be
@@ -50,7 +61,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 /// - `WorkflowStateSchema` — typed schema embedded in `Workflow`; serialized via `getVariables()`
 /// - `StateVariableDeclaration` — plain record; component accessors called during serialization
 ///
-/// ### 4. Plain records (canonical constructor + component accessors)
+/// ### 5. Plain records (canonical constructor + component accessors)
 /// Records expose state via canonical constructors and component accessors. GraalVM cannot
 /// trace these statically when Jackson uses default POJO machinery. Affected types:
 ///
@@ -83,6 +94,15 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
             PlanConstraints.class,
             Plan.class,
             PlannedStep.class,
+            // --- Nested types: manual deser, default Jackson ser ---
+            Branch.class,
+            ConsensusConfig.class,
+            ConsensusStrategy.class,
+            ConsensusResult.class,
+            ConsensusResult.Vote.class,
+            ConsensusResult.VoteType.class,
+            ScoreCondition.class,
+            DoubleRange.class,
             // --- Serialization of simple immutable types ---
             WorkflowStateSchema.class,
             StateVariableDeclaration.class,

--- a/hensu-server/src/test/java/io/hensu/server/integration/ParallelNodeIntegrationTest.java
+++ b/hensu-server/src/test/java/io/hensu/server/integration/ParallelNodeIntegrationTest.java
@@ -1,5 +1,8 @@
 package io.hensu.server.integration;
 
+import static io.hensu.core.execution.EngineVariables.APPROVED;
+import static io.hensu.core.execution.EngineVariables.RECOMMENDATION;
+import static io.hensu.core.execution.EngineVariables.SCORE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.hensu.core.state.HensuSnapshot;
@@ -12,12 +15,9 @@ import org.junit.jupiter.api.Test;
 
 /// Integration tests for parallel node execution with consensus strategies.
 ///
-/// Covers majority vote, weighted vote, unanimous, and judge-decides
-/// consensus strategies across parallel branches with stub agents.
-///
-/// ### Contracts
-/// - **Precondition**: Stub mode enabled (`hensu.stub.enabled=true`)
-/// - **Invariant**: All executions use {@link #TEST_TENANT}
+/// Stubs return structured JSON with engine variables – the same contract
+/// real LLM agents produce when the prompt enrichment pipeline injects
+/// output requirements.
 ///
 /// @see IntegrationTestBase for shared test infrastructure
 /// @see io.hensu.core.execution.parallel.ConsensusEvaluator for consensus logic
@@ -27,107 +27,101 @@ class ParallelNodeIntegrationTest extends IntegrationTestBase {
     @Test
     void shouldReachMajorityConsensus() {
         Workflow workflow = loadWorkflow("parallel-majority-vote.json");
-        registerStub("reviewer-1", "I approve this content. It meets quality standards.");
-        registerStub("reviewer-2", "I approve this submission.");
-        registerStub("reviewer-3", "I reject this content. Needs improvement.");
+        registerStub("reviewer-1", vote(90, true, "Meets quality standards"));
+        registerStub("reviewer-2", vote(85, true, "Good submission"));
+        registerStub("reviewer-3", vote(30, false, "Needs improvement"));
 
         ExecutionStartResult result = pushAndExecute(workflow, Map.of("content", "test content"));
 
-        List<HensuSnapshot> snapshots =
-                workflowStateRepository.findByWorkflowId(TEST_TENANT, result.workflowId());
-        assertThat(snapshots).isNotEmpty();
-
-        HensuSnapshot snapshot = snapshots.getLast();
-        assertThat(snapshot.checkpointReason()).isEqualTo("completed");
+        HensuSnapshot snapshot = terminalSnapshot(result);
         assertThat(snapshot.currentNodeId()).isEqualTo("consensus-reached");
     }
 
     @Test
     void shouldFailMajorityWhenInsufficient() {
         Workflow workflow = loadWorkflow("parallel-majority-vote.json");
-        registerStub("reviewer-1", "I approve this content.");
-        registerStub("reviewer-2", "I reject this submission.");
-        registerStub("reviewer-3", "I reject this content.");
+        registerStub("reviewer-1", vote(80, true, "Looks good"));
+        registerStub("reviewer-2", vote(25, false, "Poor quality"));
+        registerStub("reviewer-3", vote(20, false, "Reject"));
 
         ExecutionStartResult result = pushAndExecute(workflow, Map.of("content", "test content"));
 
-        List<HensuSnapshot> snapshots =
-                workflowStateRepository.findByWorkflowId(TEST_TENANT, result.workflowId());
-        assertThat(snapshots).isNotEmpty();
-
-        HensuSnapshot snapshot = snapshots.getLast();
-        assertThat(snapshot.checkpointReason()).isEqualTo("completed");
+        HensuSnapshot snapshot = terminalSnapshot(result);
         assertThat(snapshot.currentNodeId()).isEqualTo("no-consensus");
     }
 
     @Test
     void shouldReachWeightedConsensus() {
         Workflow workflow = loadWorkflow("parallel-weighted-vote.json");
-        registerStub("senior-reviewer", "I approve this content. Excellent quality.");
-        registerStub("junior-reviewer", "I reject this content. Not good enough.");
+        // Senior (weight=2.0) approves, junior (weight=1.0) rejects
+        // Weighted approve = 90*2.0=180, reject = 30*1.0=30 → ratio=0.86 > 0.5
+        registerStub("senior-reviewer", vote(90, true, "Excellent quality"));
+        registerStub("junior-reviewer", vote(30, false, "Not good enough"));
 
         ExecutionStartResult result = pushAndExecute(workflow, Map.of("content", "test content"));
 
-        List<HensuSnapshot> snapshots =
-                workflowStateRepository.findByWorkflowId(TEST_TENANT, result.workflowId());
-        assertThat(snapshots).isNotEmpty();
-
-        HensuSnapshot snapshot = snapshots.getLast();
-        assertThat(snapshot.checkpointReason()).isEqualTo("completed");
+        HensuSnapshot snapshot = terminalSnapshot(result);
         assertThat(snapshot.currentNodeId()).isEqualTo("consensus-reached");
     }
 
     @Test
     void shouldRequireUnanimousApproval() {
         Workflow workflow = loadWorkflow("parallel-unanimous.json");
-        registerStub("reviewer-1", "I approve this content.");
-        registerStub("reviewer-2", "I approve this content.");
-        registerStub("reviewer-3", "I approve this content.");
+        registerStub("reviewer-1", vote(95, true, "Great"));
+        registerStub("reviewer-2", vote(80, true, "Good"));
+        registerStub("reviewer-3", vote(72, true, "Acceptable"));
 
         ExecutionStartResult result = pushAndExecute(workflow, Map.of("content", "test content"));
 
-        List<HensuSnapshot> snapshots =
-                workflowStateRepository.findByWorkflowId(TEST_TENANT, result.workflowId());
-        assertThat(snapshots).isNotEmpty();
-
-        HensuSnapshot snapshot = snapshots.getLast();
-        assertThat(snapshot.checkpointReason()).isEqualTo("completed");
+        HensuSnapshot snapshot = terminalSnapshot(result);
         assertThat(snapshot.currentNodeId()).isEqualTo("consensus-reached");
     }
 
     @Test
     void shouldFailUnanimousWhenOneRejects() {
         Workflow workflow = loadWorkflow("parallel-unanimous.json");
-        registerStub("reviewer-1", "I approve this content.");
-        registerStub("reviewer-2", "I approve this content.");
-        registerStub("reviewer-3", "I reject this content.");
+        registerStub("reviewer-1", vote(90, true, "Good"));
+        registerStub("reviewer-2", vote(85, true, "Fine"));
+        registerStub("reviewer-3", vote(40, false, "Needs work"));
 
         ExecutionStartResult result = pushAndExecute(workflow, Map.of("content", "test content"));
 
-        List<HensuSnapshot> snapshots =
-                workflowStateRepository.findByWorkflowId(TEST_TENANT, result.workflowId());
-        assertThat(snapshots).isNotEmpty();
-
-        HensuSnapshot snapshot = snapshots.getLast();
-        assertThat(snapshot.checkpointReason()).isEqualTo("completed");
+        HensuSnapshot snapshot = terminalSnapshot(result);
         assertThat(snapshot.currentNodeId()).isEqualTo("no-consensus");
     }
 
     @Test
     void shouldUseJudgeForDecision() {
         Workflow workflow = loadWorkflow("parallel-judge-decides.json");
-        registerStub("reviewer-1", "I approve the content.");
-        registerStub("reviewer-2", "I reject the content.");
-        registerStub("judge", "After reviewing both opinions, I approve this content.");
+        registerStub("reviewer-1", vote(85, true, "Approve"));
+        registerStub("reviewer-2", vote(25, false, "Reject"));
+        registerStub(
+                "judge",
+                """
+                {"decision": true, "winning_branch": "branch-1", \
+                "reasoning": "Branch 1 quality is superior"}""");
 
         ExecutionStartResult result = pushAndExecute(workflow, Map.of("content", "test content"));
 
+        HensuSnapshot snapshot = terminalSnapshot(result);
+        assertThat(snapshot.currentNodeId()).isEqualTo("consensus-reached");
+    }
+
+    // -- Helpers --------------------------------------------------------------
+
+    /// Builds a structured JSON vote response using engine variable constants.
+    private static String vote(double score, boolean approved, String recommendation) {
+        return String.format(
+                "{\"%s\": %s, \"%s\": %s, \"%s\": \"%s\"}",
+                SCORE, score, APPROVED, approved, RECOMMENDATION, recommendation);
+    }
+
+    private HensuSnapshot terminalSnapshot(ExecutionStartResult result) {
         List<HensuSnapshot> snapshots =
                 workflowStateRepository.findByWorkflowId(TEST_TENANT, result.workflowId());
         assertThat(snapshots).isNotEmpty();
-
         HensuSnapshot snapshot = snapshots.getLast();
         assertThat(snapshot.checkpointReason()).isEqualTo("completed");
-        assertThat(snapshot.currentNodeId()).isEqualTo("consensus-reached");
+        return snapshot;
     }
 }

--- a/working-dir/workflows/consensus-vote.kt
+++ b/working-dir/workflows/consensus-vote.kt
@@ -1,35 +1,48 @@
 /**
- * Example of consensus-based parallel execution.
+ * Example of consensus-based parallel execution with yields.
  *
  * This workflow demonstrates:
  * - Parallel execution of multiple reviewers
  * - Majority vote consensus strategy
- * - Score-based voting determination
+ * - Branch yields: each reviewer produces domain feedback
+ * - All branch yields merge into context (vote gates transition, not data)
+ * - Downstream node consumes merged yields from all branches
+ *
+ * Note: yield field requirements are injected into the prompt automatically
+ * by YieldsVariableInjector – no need to ask the LLM for specific fields.
  */
 fun workflow() = workflow("consensus-test") {
-    description = "Example of consensus-based parallel execution"
+    description = "Consensus-based parallel review with yields"
 
     agents {
         agent("writer") {
-            model = "stub"
+            model = Models.GEMINI_3_1_PRO
             role = "Content writer"
         }
         agent("reviewer1") {
-            model = "stub"
+            model = Models.GEMINI_3_1_FLASH_LITE
             role = "Reviewer focusing on clarity"
         }
         agent("reviewer2") {
-            model = "stub"
+            model = Models.GEMINI_3_1_FLASH_LITE
             role = "Reviewer focusing on accuracy"
         }
         agent("reviewer3") {
-            model = "stub"
+            model = Models.GEMINI_3_1_FLASH_LITE
             role = "Reviewer focusing on completeness"
+        }
+        agent("editor") {
+            model = Models.GEMINI_3_1_PRO
+            role = "Content editor who incorporates review feedback"
         }
     }
 
     state {
         variable("content", VarType.STRING, "the written paragraph to review")
+        variable("clarity_feedback", VarType.STRING, "clarity reviewer's feedback on the content")
+        variable("accuracy_feedback", VarType.STRING, "accuracy reviewer's feedback on the content")
+        variable("completeness_feedback", VarType.STRING, "completeness reviewer's feedback on the content")
+        variable("revised_content", VarType.STRING, "content revised based on reviewer feedback")
     }
 
     graph {
@@ -43,39 +56,25 @@ fun workflow() = workflow("consensus-test") {
             onSuccess goto "review"
         }
 
-        // Parallel review with consensus
+        // Parallel review with consensus – each branch yields domain feedback.
+        // YieldsVariableInjector auto-injects the output field requirements.
         parallel("review") {
             branch("clarity_review") {
                 agent = "reviewer1"
-                prompt = """
-                    Review the following content for clarity:
-
-                    {content}
-
-                    Provide your assessment with a score (0-100) and decision.
-                """.trimIndent()
+                prompt = "Review the following content for clarity: {content}"
+                yields("clarity_feedback")
             }
 
             branch("accuracy_review") {
                 agent = "reviewer2"
-                prompt = """
-                    Review the following content for accuracy:
-
-                    {content}
-
-                    Provide your assessment with a score (0-100) and decision.
-                """.trimIndent()
+                prompt = "Review the following content for accuracy: {content}"
+                yields("accuracy_feedback")
             }
 
             branch("completeness_review") {
                 agent = "reviewer3"
-                prompt = """
-                    Review the following content for completeness:
-
-                    {content}
-
-                    Provide your assessment with a score (0-100) and decision.
-                """.trimIndent()
+                prompt = "Review the following content for completeness: {content}"
+                yields("completeness_feedback")
             }
 
             consensus {
@@ -83,8 +82,26 @@ fun workflow() = workflow("consensus-test") {
                 threshold = 0.5
             }
 
-            onConsensus goto "approved"
+            onConsensus goto "revise"
             onNoConsensus goto "rejected"
+        }
+
+        // Downstream node consumes merged yields from winning branches
+        node("revise") {
+            agent = "editor"
+            prompt = """
+                Revise the following content based on reviewer feedback:
+
+                Original: {content}
+
+                Clarity feedback: {clarity_feedback}
+                Accuracy feedback: {accuracy_feedback}
+                Completeness feedback: {completeness_feedback}
+
+                Produce an improved version addressing all feedback.
+            """.trimIndent()
+            writes("revised_content")
+            onSuccess goto "approved"
         }
 
         end("approved", ExitStatus.SUCCESS)

--- a/working-dir/workflows/judge-decides.kt
+++ b/working-dir/workflows/judge-decides.kt
@@ -1,0 +1,119 @@
+/**
+ * Example of JUDGE_DECIDES consensus strategy with yields.
+ *
+ * This workflow demonstrates:
+ * - Parallel execution of competing proposal writers
+ * - A senior judge agent that reviews all branch outputs and picks the winner
+ * - Branch yields: each proposer produces a domain artifact (proposal_text)
+ * - Only the judge-selected winner's yields merge into context
+ * - Downstream node refines the winning proposal
+ *
+ * Unlike MAJORITY_VOTE where branches vote on shared content,
+ * JUDGE_DECIDES is ideal when branches produce competing alternatives
+ * and an expert must choose the best one.
+ */
+fun workflow() = workflow("judge-decides-test") {
+    description = "Judge-based consensus: competing proposals evaluated by a senior agent"
+
+    agents {
+        agent("proposer1") {
+            model = Models.GEMINI_3_1_FLASH_LITE
+            role = "Creative proposal writer focusing on innovation"
+        }
+        agent("proposer2") {
+            model = Models.GEMINI_3_1_FLASH_LITE
+            role = "Practical proposal writer focusing on feasibility"
+        }
+        agent("proposer3") {
+            model = Models.GEMINI_3_1_FLASH_LITE
+            role = "Risk-aware proposal writer focusing on safety"
+        }
+        agent("judge") {
+            model = Models.GEMINI_3_1_PRO
+            role = "Senior technical lead who evaluates competing proposals and selects the best approach"
+        }
+        agent("refiner") {
+            model = Models.GEMINI_3_1_PRO
+            role = "Technical writer who polishes the selected proposal"
+        }
+    }
+
+    state {
+        variable("topic", VarType.STRING, "the technical topic for proposals")
+        variable("proposal_innovative", VarType.STRING, "innovation-focused proposal")
+        variable("proposal_practical", VarType.STRING, "feasibility-focused proposal")
+        variable("proposal_safe", VarType.STRING, "safety-focused proposal")
+        variable("final_proposal", VarType.STRING, "the refined final proposal")
+    }
+
+    graph {
+        start at "set-topic"
+
+        node("set-topic") {
+            agent = "proposer1"
+            prompt = "In one sentence, state the topic: 'How should a startup approach building its first CI/CD pipeline?'. Return it as the topic field."
+            writes("topic")
+            onSuccess goto "proposals"
+        }
+
+        // Parallel competing proposals - judge picks the winner
+        parallel("proposals") {
+            branch("innovative") {
+                agent = "proposer1"
+                prompt = """
+                    Write a short proposal (2-3 sentences) on: {topic}
+                    Focus on innovative, cutting-edge approaches.
+                """.trimIndent()
+                yields("proposal_innovative")
+            }
+
+            branch("practical") {
+                agent = "proposer2"
+                prompt = """
+                    Write a short proposal (2-3 sentences) on: {topic}
+                    Focus on practical, battle-tested approaches.
+                """.trimIndent()
+                yields("proposal_practical")
+            }
+
+            branch("safe") {
+                agent = "proposer3"
+                prompt = """
+                    Write a short proposal (2-3 sentences) on: {topic}
+                    Focus on risk mitigation and reliability.
+                """.trimIndent()
+                yields("proposal_safe")
+            }
+
+            consensus {
+                strategy = ConsensusStrategy.JUDGE_DECIDES
+                judge = "judge"
+            }
+
+            onConsensus goto "refine"
+            onNoConsensus goto "rejected"
+        }
+
+        // Refine the winning proposal
+        node("refine") {
+            agent = "refiner"
+            prompt = """
+                You are refining the winning proposal selected by the judge.
+
+                Topic: {topic}
+
+                Winning proposal (innovative): {proposal_innovative}
+                Winning proposal (practical): {proposal_practical}
+                Winning proposal (safe): {proposal_safe}
+
+                Note: only the winning branch's yield is populated above.
+                Produce a polished final version of the available proposal.
+            """.trimIndent()
+            writes("final_proposal")
+            onSuccess goto "approved"
+        }
+
+        end("approved", ExitStatus.SUCCESS)
+        end("rejected", ExitStatus.FAILURE)
+    }
+}

--- a/working-dir/workflows/llm-evaluation.kt
+++ b/working-dir/workflows/llm-evaluation.kt
@@ -20,19 +20,19 @@ fun llmEvalTestWorkflow() = workflow("llm-eval-test") {
     agents {
         agent("writer") {
             role = "Technical content writer. Return JSON with key: article."
-            model = Models.CLAUDE_SONNET_4_5
+            model = Models.GEMINI_3_1_FLASH_LITE
             temperature = 0.7
         }
 
         agent("evaluator") {
             role = "Content quality evaluator. Return JSON with keys: reasoning, improvements."
-            model = Models.CLAUDE_SONNET_4_5
+            model = Models.CLAUDE_OPUS_4_5
             temperature = 0.2
         }
 
         agent("editor") {
             role = "Editor who revises content. Return JSON with key: article."
-            model = Models.CLAUDE_SONNET_4_5
+            model = Models.GEMINI_3_1_PRO
             temperature = 0.5
         }
     }

--- a/working-dir/workflows/param-extraction.kt
+++ b/working-dir/workflows/param-extraction.kt
@@ -19,7 +19,7 @@ fun paramExtractionWorkflow() = workflow("ParamExtraction") {
     agents {
         agent("researcher") {
             role = "Research Assistant"
-            model = Models.GEMINI_2_5_FLASH
+            model = Models.GEMINI_3_1_FLASH_LITE
             temperature = 0.3  // Lower temperature for more precise outputs
         }
     }

--- a/working-dir/workflows/unanimous-vote.kt
+++ b/working-dir/workflows/unanimous-vote.kt
@@ -1,0 +1,121 @@
+/**
+ * Example of UNANIMOUS consensus strategy with yields.
+ *
+ * This workflow demonstrates:
+ * - Parallel execution of multiple security auditors
+ * - Unanimous consensus: ALL branches must approve for consensus
+ * - Branch yields: each auditor produces domain-specific findings
+ * - All yields merge into context regardless of vote outcome
+ * - Downstream node compiles the final security report
+ *
+ * Use UNANIMOUS when every reviewer must agree before proceeding –
+ * a single rejection blocks the pipeline (e.g. security gates,
+ * compliance checks, release sign-offs).
+ */
+fun workflow() = workflow("unanimous-test") {
+    description = "Unanimous consensus: all auditors must approve"
+
+    agents {
+        agent("author") {
+            model = Models.GEMINI_3_1_FLASH_LITE
+            role = "Technical writer drafting a security policy"
+        }
+        agent("auditor1") {
+            model = Models.GEMINI_3_1_FLASH_LITE
+            role = "Security auditor focusing on access control"
+        }
+        agent("auditor2") {
+            model = Models.GEMINI_3_1_FLASH_LITE
+            role = "Security auditor focusing on data encryption"
+        }
+        agent("auditor3") {
+            model = Models.GEMINI_3_1_FLASH_LITE
+            role = "Security auditor focusing on compliance"
+        }
+        agent("compiler") {
+            model = Models.GEMINI_3_1_PRO
+            role = "Report compiler who synthesizes audit findings into a final report"
+        }
+    }
+
+    state {
+        variable("policy_draft", VarType.STRING, "the security policy draft to audit")
+        variable("access_findings", VarType.STRING, "access control audit findings")
+        variable("encryption_findings", VarType.STRING, "data encryption audit findings")
+        variable("compliance_findings", VarType.STRING, "compliance audit findings")
+        variable("final_report", VarType.STRING, "compiled security audit report")
+    }
+
+    graph {
+        start at "draft-policy"
+
+        node("draft-policy") {
+            agent = "author"
+            prompt = "Write a short security policy (2-3 sentences) about API key management for a cloud SaaS product."
+            writes("policy_draft")
+            onSuccess goto "audit"
+        }
+
+        parallel("audit") {
+            branch("access_review") {
+                agent = "auditor1"
+                prompt = """
+                    Audit the following security policy for access control gaps:
+                    {policy_draft}
+
+                    Identify any missing access control requirements.
+                """.trimIndent()
+                yields("access_findings")
+            }
+
+            branch("encryption_review") {
+                agent = "auditor2"
+                prompt = """
+                    Audit the following security policy for encryption gaps:
+                    {policy_draft}
+
+                    Identify any missing encryption requirements.
+                """.trimIndent()
+                yields("encryption_findings")
+            }
+
+            branch("compliance_review") {
+                agent = "auditor3"
+                prompt = """
+                    Audit the following security policy for compliance gaps:
+                    {policy_draft}
+
+                    Check against SOC2 and GDPR requirements.
+                """.trimIndent()
+                yields("compliance_findings")
+            }
+
+            consensus {
+                strategy = ConsensusStrategy.UNANIMOUS
+            }
+
+            onConsensus goto "compile-report"
+            onNoConsensus goto "blocked"
+        }
+
+        node("compile-report") {
+            agent = "compiler"
+            prompt = """
+                Compile a brief security audit report from the following findings:
+
+                Policy: {policy_draft}
+
+                Access control findings: {access_findings}
+                Encryption findings: {encryption_findings}
+                Compliance findings: {compliance_findings}
+
+                Produce a concise summary with all findings addressed.
+            """.trimIndent()
+            writes("final_report")
+            onSuccess goto "approved"
+        }
+
+        end("approved", ExitStatus.SUCCESS)
+        end("blocked", ExitStatus.FAILURE)
+    }
+}

--- a/working-dir/workflows/weighted-vote.kt
+++ b/working-dir/workflows/weighted-vote.kt
@@ -1,0 +1,126 @@
+/**
+ * Example of WEIGHTED_VOTE consensus strategy with yields.
+ *
+ * This workflow demonstrates:
+ * - Parallel execution of reviewers with different weights
+ * - Weighted vote consensus: weighted approval ratio must meet threshold
+ * - Senior reviewer has higher weight (influence) than junior reviewers
+ * - Branch yields: each reviewer produces domain feedback
+ * - All yields merge into context regardless of vote outcome
+ * - Downstream node incorporates all feedback
+ *
+ * Use WEIGHTED_VOTE when some reviewers carry more authority than others –
+ * e.g. a senior engineer's review outweighs a junior's, or a domain
+ * expert's opinion matters more than a generalist's.
+ */
+fun workflow() = workflow("weighted-vote-test") {
+    description = "Weighted consensus: senior reviewer has more influence"
+
+    agents {
+        agent("writer") {
+            model = Models.GEMINI_3_1_PRO
+            role = "API documentation writer"
+        }
+        agent("junior1") {
+            model = Models.GEMINI_3_1_FLASH_LITE
+            role = "Junior reviewer focusing on readability"
+        }
+        agent("junior2") {
+            model = Models.GEMINI_3_1_FLASH_LITE
+            role = "Junior reviewer focusing on examples"
+        }
+        agent("senior") {
+            model = Models.GEMINI_3_1_PRO
+            role = "Senior API architect reviewing technical accuracy and completeness"
+        }
+        agent("editor") {
+            model = Models.GEMINI_3_1_PRO
+            role = "Technical editor who incorporates weighted review feedback"
+        }
+    }
+
+    state {
+        variable("api_docs", VarType.STRING, "the API documentation draft")
+        variable("readability_feedback", VarType.STRING, "readability review feedback")
+        variable("examples_feedback", VarType.STRING, "examples and usage review feedback")
+        variable("architecture_feedback", VarType.STRING, "senior architect's technical review")
+        variable("final_docs", VarType.STRING, "the revised API documentation")
+    }
+
+    graph {
+        start at "write-docs"
+
+        node("write-docs") {
+            agent = "writer"
+            prompt = "Write a short API endpoint documentation (2-3 sentences) for a POST /users endpoint that creates a new user. Include example"
+            writes("api_docs")
+            onSuccess goto "review"
+        }
+
+        parallel("review") {
+            branch("readability") {
+                agent = "junior1"
+                weight = 0.3
+                prompt = """
+                    Review the following API documentation for readability:
+                    {api_docs}
+
+                    Is it clear and easy to follow for new developers?
+                """.trimIndent()
+                yields("readability_feedback")
+            }
+
+            branch("examples") {
+                agent = "junior2"
+                weight = 0.3
+                prompt = """
+                    Review the following API documentation for examples:
+                    {api_docs}
+
+                    Does it include sufficient usage examples?
+                """.trimIndent()
+                yields("examples_feedback")
+            }
+
+            branch("architecture") {
+                agent = "senior"
+                weight = 0.7
+                prompt = """
+                    Review the following API documentation for technical accuracy:
+                    {api_docs}
+
+                    Check for correct HTTP methods, status codes, and security considerations.
+                """.trimIndent()
+                yields("architecture_feedback")
+            }
+
+            consensus {
+                strategy = ConsensusStrategy.WEIGHTED_VOTE
+                threshold = 0.5
+            }
+
+            onConsensus goto "revise"
+            onNoConsensus goto "rejected"
+        }
+
+        node("revise") {
+            agent = "editor"
+            prompt = """
+                Revise the API documentation based on all reviewer feedback:
+
+                Original: {api_docs}
+
+                Readability feedback: {readability_feedback}
+                Examples feedback: {examples_feedback}
+                Senior architect feedback: {architecture_feedback}
+
+                Produce an improved version addressing all feedback.
+            """.trimIndent()
+            writes("final_docs")
+            onSuccess goto "approved"
+        }
+
+        end("approved", ExitStatus.SUCCESS)
+        end("rejected", ExitStatus.FAILURE)
+    }
+}


### PR DESCRIPTION
- Introduce yields(String...) on parallel branches for structured domain output via the inject→execute→extract pipeline.
- Rewrite ConsensusEvaluator to use structured BranchResult data, fixing 6 bugs in heuristic-based vote extraction.
- Extract AgentLifecycleRunner to unify agent execution across StandardNodeExecutor and ParallelNodeExecutor, restoring missing listener events on branches.

Resolve: #59