### PR TITLE
feat(agent): agent-native tool loop, replacing plan-subsystem tool path

### DIFF
--- a/.claude/commands/assess-claude.md
+++ b/.claude/commands/assess-claude.md
@@ -13,7 +13,7 @@ Token rule: see `01-model-coordination.md` §2. Never read files into your own c
    - Uncommitted → `git diff > .claude/tmp/subject.patch` then `@.claude/tmp/subject.patch`.
    - Add ≤2 lines rationale.
 
-2. **Query Gemini** (`mcp__gemini__ask-gemini`, `gemini-3.1-pro-preview`):
+2. **Query Gemini** (`mcp__gemini__ask-gemini`, `gemini-3.6-flash`):
 > Cynical Researcher. Read referenced paths. Audit against:
 > (1) Correctness — edge cases, concurrency, error paths.
 > (2) Hensu invariants — GraalVM native (no reflection/classpath scanning/ThreadLocal), virtual-thread safety (no pinning `synchronized`), multi-tenant ScopedValue isolation.

--- a/.claude/commands/doc-staleness.md
+++ b/.claude/commands/doc-staleness.md
@@ -1,0 +1,37 @@
+---
+description: Check and fix stale documentation after a code change.
+---
+# Doc Staleness Check
+
+Target: $ARGUMENTS (branch name, PR description, or "current diff").
+
+Walk documentation in dependency order. Each step is a **separate user interaction** — report
+staleness findings, then wait for "fix" or "skip" before proceeding.
+
+## Step order
+
+1. **Core module** — `hensu-core/README.md` + `docs/developer-guide-core.md`
+2. **DSL** — `hensu-dsl/README.md` + `docs/dsl-reference.md`
+3. **Server** — `hensu-server/README.md` + `docs/developer-guide-server.md`
+4. **Serialization** — `hensu-serialization/README.md` + `docs/developer-guide-serialization.md`
+5. **CLI** — `hensu-cli/README.md`
+6. **Architecture** — `docs/unified-architecture.md`
+7. **Cross-cutting** — `AGENTS.md`
+8. **Root** — `README.md`
+
+## Per-step procedure
+
+1. Read the target doc(s) for the current step.
+2. Compare against the change set (diff, new files, modified interfaces).
+3. Report findings as a numbered list: line range, what is stale, why.
+4. If nothing is stale, say "Not stale" and move to the next step automatically.
+5. If stale, wait for user to say "fix" or "skip".
+6. After fix/skip, move to the next step.
+
+## Rules
+
+- Never batch multiple steps — one step per turn.
+- "Not stale" steps auto-advance; stale steps pause.
+- When fixing, prefer minimal edits that match existing prose style.
+- Do not add content beyond what the change set requires.
+- Follow `02-output-density.md` for chat replies.

--- a/.claude/commands/test-audit.md
+++ b/.claude/commands/test-audit.md
@@ -11,7 +11,7 @@ Token rule: see `01-model-coordination.md` §2. Never inline test code or diffs.
    - Files/dirs → `@path` (glob-friendly).
    - Uncommitted tests → `git diff -- '*Test*' '*test*' > .claude/tmp/tests.patch` then `@.claude/tmp/tests.patch`.
 
-2. **Query Gemini** (`mcp__gemini__ask-gemini`, `gemini-3.1-pro-preview`):
+2. **Query Gemini** (`mcp__gemini__ask-gemini`, `gemini-3.6-flash`):
 > Cynical Researcher. Read referenced test paths. Question: "Can this catch a real prod bug?"
 > Repo has ~1000 tests; net delta must be ≤ 0. Prefer DROP.
 > Classify:

--- a/.claude/rules/01-model-coordination.md
+++ b/.claude/rules/01-model-coordination.md
@@ -15,7 +15,7 @@ Ping `mcp__gemini__ping` at session start.
 ## Model Routing
 
 - **Discovery / Indexing:** `gemini-3.1-flash-lite`
-- **Logic / Refactoring:** `gemini-3.1-pro-preview`
+- **Logic / Refactoring:** `gemini-3.6-flash`
 
 ## Discovery Rule (Dual-Model)
 

--- a/.cursor/rules/01-model-coordination.mdc
+++ b/.cursor/rules/01-model-coordination.mdc
@@ -19,7 +19,7 @@ Ping `mcp__gemini__ping` at session start.
 ## Model Routing
 
 - **Discovery / Indexing:** `gemini-3.1-flash-lite`
-- **Logic / Refactoring:** `gemini-3.1-pro-preview`
+- **Logic / Refactoring:** `gemini-3.6-flash`
 
 ## Discovery Rule (Dual-Model)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Hensu is a modular AI workflow engine on Java 25 + Kotlin DSL. Core design princ
 4. **Template resolution**: `{variable}` syntax in prompts, resolved via `SimpleTemplateResolver`
 5. **`@DslMarker`** on Kotlin builders to prevent scope leakage
 6. **Engine variables** (`score`, `approved`, `recommendation`): engine-managed, never declared in `writes()` or `state{}`. Surfaced to the next node by the `EngineVariablePromptEnricher` injectors (`FeedbackContextInjector` appends prior feedback as a `### Previous Feedback` section). A backtracking `revise` arm preserves them; a plain forward `goto` clears them unless marked `withFeedback`.
+7. **Agent tool loop**: agents implementing `ToolCapable` open a call-scoped `ToolSession` and execute tools natively via `ToolLoopRunner` — the sealed `AgentResponse` hierarchy (`TextResponse`/`ToolRequest`/`Error`) controls flow. Budget enforced by `AgentConfig.maxToolCalls` (default 10, counting executed calls). Agent-originated tool args use `Action.Send(rawPayload=true)` to skip template resolution (prevents context exfiltration).
 
 ## Key Architectural Rules
 
@@ -34,7 +35,7 @@ Hensu is a modular AI workflow engine on Java 25 + Kotlin DSL. Core design princ
 6. **Storage in core**: repository interfaces and in-memory defaults live in `hensu-core`. JDBC impls live in `hensu-server/persistence/` as plain classes (not CDI beans). `HensuEnvironmentProducer` conditionally wires JDBC vs in-memory. Server exposes core components via `@Produces @Singleton` — never instantiates directly.
 7. **API separation**: `/api/v1/workflows` (definitions) and `/api/v1/executions` (runtime) are distinct resources.
 8. **JWT authentication**: SmallRye JWT bearer auth. Tenant identity extracted from `tenant_id` claim via `RequestTenantResolver`. CLI sends `Authorization: Bearer <token>` via `--token` or `hensu.server.token` config. JWT is required in every profile **except `inmem`** (integration tests), which disables auth and uses `hensu.tenant.default`. RSA keys live outside the repo (e.g. `~/.hensu/`).
-9. **Nodes do work; transitions route.** Control-flow capabilities (iteration, exit conditions, budgets, feedback) are expressed in the `TransitionRule` sealed hierarchy — never as node types, node flags, or executor forks on node configuration. A request shaped like "this node needs to loop/branch/retry/converge" is answered with a new or extended transition rule wired through `requiredEngineVars()`. The plan subsystem and `LoopNode` were both removed for violating this; do not reintroduce the pattern.
+9. **Nodes do work; transitions route.** Control-flow capabilities (iteration, exit conditions, budgets, feedback) are expressed in the `TransitionRule` sealed hierarchy — never as node types, node flags, or executor forks on node configuration. A request shaped like "this node needs to loop/branch/retry/converge" is answered with a new or extended transition rule wired through `requiredEngineVars()`. `LoopNode` was removed for violating this; the plan subsystem is next (PR5). Do not reintroduce the pattern.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ fun contentPipeline() = workflow("content-pipeline") {
 ```
 
 The [DSL Reference](docs/dsl-reference.md) covers condition-based routing (`onCondition` —
-bounded self-revising work loops), parallel branches, consensus, dynamic planning, fork/join,
-and sub-workflows.
+bounded self-revising work loops), tool-equipped agents, parallel branches, consensus, dynamic
+planning, fork/join, and sub-workflows.
 
 ---
 
@@ -177,6 +177,8 @@ and sub-workflows.
 
 - **Rubric evaluation.** Automated quality gates score outputs against markdown rubric definitions
   and route on thresholds — self-correcting loops without custom parsing code.
+- **Agent-native tool loop.** Agents implementing `ToolCapable` drive tool calls directly via
+  `ToolSession` — budget-bounded by `maxToolCalls`, with `rawPayload` safety on LLM-generated arguments.
 - **Agentic planning.** Static (predefined) or dynamic (LLM-generated) execution plans within nodes,
   with mid-plan review gates.
 - **Time-travel backtracking.** Rewind to any previous node mid-flight, optionally edit the prompt

--- a/docs/developer-guide-core.md
+++ b/docs/developer-guide-core.md
@@ -25,6 +25,7 @@ This guide covers API usage, adapter development, extension points, and testing 
   - [Bounded Revise](#bounded-revise)
 - [State Schema](#state-schema)
 - [Engine Variable Injection](#engine-variable-injection)
+- [Agent Tool Loop](#agent-tool-loop)
 - [Tool Registry](#tool-registry)
 - [Plan Engine](#plan-engine)
 - [Template Resolution](#template-resolution)
@@ -978,9 +979,92 @@ EngineVariablePromptEnricher enricher = new EngineVariablePromptEnricher(
 
 Inject it via `HensuFactory` or override the server CDI producer.
 
+## Agent Tool Loop
+
+Agents that implement `ToolCapable` can natively request and receive tool results during execution,
+without routing through the plan subsystem. The loop is driven by `ToolLoopRunner`, dispatched from
+`AgentLifecycleRunner` when a node declares tools.
+
+### Protocol
+
+Three types form the tool session protocol (all in `hensu-core`, zero external deps):
+
+| Type             | Description                                                                                         |
+|------------------|-----------------------------------------------------------------------------------------------------|
+| `ToolCapable`    | Narrow interface on agents: `openToolSession(prompt, context, tools)` returns a `ToolSession`       |
+| `ToolSession`    | Call-scoped session: `start()`, `submit(ToolCallResult)`, `compact()`, `close()`                    |
+| `ToolCallResult` | Record `(toolName, success, output, error)` with `success()`/`failure()` factories and `asText()`   |
+
+Sessions are call-scoped, not stateful on the agent – `ParallelNodeExecutor` fan-out shares one agent
+instance across branches, so loop state must not live on the agent.
+
+### Termination Semantics
+
+The sealed `AgentResponse` hierarchy IS the termination signal – no explicit "done" message:
+
+| Response       | Meaning                                      |
+|----------------|----------------------------------------------|
+| `TextResponse` | Loop DONE – agent produced final answer      |
+| `ToolRequest`  | Loop continues – another tool call round     |
+| `Error`        | Loop DONE – agent errored                    |
+
+### Engagement
+
+`ToolLoopRunner` engages when both conditions hold:
+1. `agent.getConfig().getTools()` is non-empty
+2. `agent instanceof ToolCapable`
+
+Tools declared but agent not capable → `NodeResult.failure()` (routable via `onFailure`).
+
+### Tool Resolution
+
+Tools are resolved via the MCP discovery chain:
+1. `ctx.getToolRegistry().all()` returns all available tools (in server context: `TenantToolRegistry` → `McpToolDiscovery`)
+2. Filter to the agent's declared `tools` names
+3. Unresolvable name → `NodeResult.failure()` with diagnostic listing available tools
+4. Filtered `List<ToolDefinition>` (with full schemas) passed into `openToolSession()`
+
+### Budget Enforcement
+
+`AgentConfig.maxToolCalls` (default 10) caps EXECUTED tool calls – each `Action.Send` counts, so one
+round with N parallel calls from the model counts N (not 1).
+
+On cap exhaustion:
+1. Feed back `ToolCallResult.failure(lastToolName, "Tool call budget exhausted (N/N)...")` via `session.submit()`
+2. Model responds with `TextResponse` → **SUCCESS** (accumulated context preserved)
+3. Model responds with `ToolRequest` → **hard FAILURE** ("agent continued requesting tools after budget exhaustion")
+
+No retry, no counter reset. If an agent genuinely needs more budget, raise `maxToolCalls` in the DSL.
+
+### Safety: Raw Payloads
+
+Agent-originated tool arguments are dispatched as `Action.Send(..., rawPayload=true)`. The `rawPayload`
+flag prevents template resolution of LLM-generated content – without it, an argument containing `{secret_key}`
+would be expanded from workflow context (template exfiltration). DSL-authored sends use `rawPayload=false`
+and continue to resolve templates normally.
+
+### Unknown Tools
+
+When an agent requests a tool name that doesn't exist (hallucination), the runner feeds back
+`ToolCallResult.failure(toolName, "Unknown tool 'X', available: [...]")` rather than hard-failing.
+The agent can retry or answer – budget bounds the loop.
+
+### Session Lifecycle
+
+`ToolLoopRunner` wraps the loop in try/finally:
+- `session.compact()` before the cap-exhaustion final call (maximize context for summarization)
+- `session.close()` in the finally block (release resources, flush final pair to shared history)
+
+### Adapter Implementations
+
+| Adapter        | Class                    | Notes                                                                        |
+|----------------|--------------------------|------------------------------------------------------------------------------|
+| LangChain4j    | `LangChain4jToolSession` | Multi-tool queue draining, `ReentrantLock`-guarded history, system-msg merge |
+| Stub (testing) | `StubToolSession`        | Scripted turns via `---TURN---` separator, `[TOOL_CALL]` prefix for requests |
+
 ## Tool Registry
 
-Protocol-agnostic tool descriptors used by plan generation and MCP integration. The core defines tool shapes; actual invocation happens through `ActionHandler` at the application layer.
+Protocol-agnostic tool descriptors used by agent tool loops, plan generation, and MCP integration. The core defines tool shapes; actual invocation happens through `ActionHandler` at the application layer.
 
 ### Registering Tools
 
@@ -1000,10 +1084,11 @@ registry.register(ToolDefinition.of("analyze", "Analyze data",
 
 ### MCP Integration
 
-The server layer populates the tool registry from MCP server connections. Tools discovered via MCP become `ToolDefinition` instances available for plan generation and execution.
+The server layer populates the tool registry from MCP server connections. Tools discovered via MCP become `ToolDefinition` instances available for agent tool loops and plan generation.
 
 ```
-MCP Server ──► ToolDefinition ──► ToolRegistry ──► Planner ──► Plan
+MCP Server ──► ToolDefinition ──► ToolRegistry ──┬──► ToolLoopRunner ──► Agent Tool Session
+                                                 └──► Planner ──► Plan
 ```
 
 ## Plan Engine
@@ -1112,6 +1197,10 @@ The `TemplateResolver` substitutes `{variable}` placeholders in prompts from wor
 - `{topic}` — resolved from initial context or previous node output
 - `{nodeId}` — resolved from the output of node with that ID (legacy mode — no schema declared)
 - `{varName}` — resolved from named state variables written via `writes` (schema mode)
+
+Template resolution applies only to DSL-authored payloads (`Action.Send` with `rawPayload=false`).
+Agent-originated tool arguments (`rawPayload=true`) bypass resolution entirely to prevent template
+exfiltration – an LLM-generated argument containing `{secret}` must not expand from workflow context.
 
 ## Human Review
 
@@ -1458,7 +1547,10 @@ Environment variables matching `*_API_KEY`, `*_KEY`, `*_SECRET`, or `*_TOKEN` pa
 | `agent/AgentProvider.java`                              | Provider interface for pluggable AI backends                                                     |
 | `agent/AgentRegistry.java`                              | Agent lookup interface                                                                           |
 | `agent/DefaultAgentRegistry.java`                       | Thread-safe agent registry                                                                       |
+| `agent/ToolCapable.java`                                | Narrow interface for agents that support tool sessions                                           |
+| `agent/ToolSession.java`                                | Call-scoped tool loop session (start/submit/compact/close)                                       |
 | `agent/stub/StubAgentProvider.java`                     | Testing provider (priority 1000 when enabled)                                                    |
+| `agent/stub/StubToolSession.java`                       | Scripted tool session for testing (`---TURN---` syntax)                                          |
 | `execution/WorkflowExecutor.java`                       | Main execution engine                                                                            |
 | `execution/NodeLifecycleCoordinator.java`               | Per-node lifecycle: phase dispatch, pipeline orchestration                                       |
 | `execution/executor/GenericNodeHandler.java`            | Generic node handler interface                                                                   |
@@ -1488,6 +1580,7 @@ Environment variables matching `*_API_KEY`, `*_KEY`, `*_SECRET`, or `*_TOKEN` pa
 | `rubric/RubricEngine.java`                              | Quality evaluation engine                                                                        |
 | `rubric/model/Rubric.java`                              | Rubric definition model                                                                          |
 | `tool/ToolDefinition.java`                              | Protocol-agnostic tool descriptor                                                                |
+| `tool/ToolCallResult.java`                              | Tool execution result record (success/failure factories, `asText()`)                             |
 | `tool/ToolRegistry.java`                                | Tool registration/lookup interface                                                               |
 | `plan/PlanExecutor.java`                                | Iterates plan steps via `StepHandlerRegistry`                                                    |
 | `plan/Plan.java`                                        | Plan model (steps + constraints)                                                                 |
@@ -1506,6 +1599,7 @@ Environment variables matching `*_API_KEY`, `*_KEY`, `*_SECRET`, or `*_TOKEN` pa
 | `execution/EngineVariables.java`                        | SSOT for engine variable names (`score`, `approved`, `recommendation`)                           |
 | `execution/SynchronizedListenerDecorator.java`          | Thread-safe listener wrapper for parallel branch execution                                       |
 | `execution/executor/AgentLifecycleRunner.java`          | Composition-based agent call: prompt enrichment → agent execution → output extraction            |
+| `execution/executor/ToolLoopRunner.java`                | Drives agent-native tool loop (budget enforcement, feed-back, sealed termination)                |
 | `execution/executor/AgenticNodeExecutor.java`           | Drives preparation + execution `PlanPipeline`s for `StandardNode`                                |
 | `execution/parallel/BranchExecutionConfig.java`         | Typed branch metadata on `ExecutionContext` (consensus strategy, yields list)                    |
 | `template/SimpleTemplateResolver.java`                  | `{variable}` substitution                                                                        |

--- a/docs/developer-guide-server.md
+++ b/docs/developer-guide-server.md
@@ -195,6 +195,7 @@ public HensuEnvironment hensuEnvironment() {
             .loadCredentials(properties)
             .agentProviders(List.of(new LangChain4jProvider()))
             .actionExecutor(actionExecutor)   // ServerActionExecutor (send-action dispatcher)
+            .toolRegistry(tenantToolRegistry) // MCP-discovered tools for agent tool loops + planning
             .planObservers(planObservers.stream().toList())
             .planResponseParser(new JacksonPlanResponseParser(objectMapper));
 
@@ -254,7 +255,7 @@ public ObjectMapper objectMapper() {
 
 ### ServerActionExecutor
 
-Server-specific `ActionExecutor` that routes `Action.Send` to registered handlers (such as `McpSidecar`) and rejects `Action.Execute` (local command execution):
+Server-specific `ActionExecutor` that routes `Action.Send` to registered handlers (such as `McpSidecar`) and rejects `Action.Execute` (local command execution). When `send.isRawPayload()` is true (agent-originated tool calls via `ToolLoopRunner`), template resolution is skipped to prevent exfiltration of workflow context through LLM-generated arguments:
 
 ```java
 @Override
@@ -264,6 +265,13 @@ public ActionResult execute(Action action, Map<String, Object> context) {
         case Action.Execute exec -> ActionResult.failure(
             "Server mode does not support local command execution");
     };
+}
+
+private ActionResult executeSend(Action.Send send, Map<String, Object> context) {
+    Map<String, Object> payload = send.isRawPayload()
+            ? send.getPayload()                    // agent-originated: skip template resolution
+            : resolvePayload(send, context);       // DSL-authored: resolve {variable} placeholders
+    // ... handler lookup and dispatch
 }
 ```
 
@@ -867,6 +875,10 @@ MCP tools are discovered at runtime — no server code changes are required to s
   their own MCP implementations.
 - **No server changes**: `McpSidecar.execute()` resolves tool names dynamically from the JSON-RPC
   payload. Adding a new tool on the MCP server side is sufficient; no `McpSidecar` update is needed.
+- **Consumers**: `TenantToolRegistry` is wired into `HensuFactory` via `HensuEnvironmentProducer`,
+  making discovered tools available to both `ToolLoopRunner` (agent-native tool loops) and
+  `PlanExecutor` (plan-based tool execution). Before PR4, the tool registry was never wired in the
+  server context — planning ran against an empty registry.
 
 ---
 

--- a/docs/dsl-reference.md
+++ b/docs/dsl-reference.md
@@ -108,6 +108,7 @@ agents {
 | `temperature`      | Double       | No       | 0.7         | Sampling temperature (0.0-2.0)                                       |
 | `maxTokens`        | Int?         | No       | null        | Maximum tokens in response (null = model default)                    |
 | `tools`            | List<String> | No       | emptyList() | Tool identifiers available to this agent                             |
+| `maxToolCalls`     | Int?         | No       | null        | Maximum tool calls per node execution (null = engine default of 10)  |
 | `maintainContext`  | Boolean      | No       | false       | Whether to maintain conversation context across executions           |
 | `instructions`     | String?      | No       | null        | Additional system instructions appended to role                      |
 | `topP`             | Double?      | No       | null        | Top-p (nucleus) sampling parameter (0.0-1.0)                         |

--- a/docs/unified-architecture.md
+++ b/docs/unified-architecture.md
@@ -15,8 +15,9 @@ maintaining distributed lease state (`serverNodeId`, heartbeats) across the clus
 
 - **Macro-Graph:** The static, declarative flow defined in the DSL — which nodes run, in what order, with what
   transitions. This is the **strategy**.
-- **Micro-Plan:** The dynamic, step-by-step execution logic within a single node — tool calls, replanning, reflection
-  loops. This is the **tactics**.
+- **Micro-Tactics:** The dynamic execution logic within a single node. Two paths: an **agent-native tool loop**
+  (`ToolLoopRunner`) where the agent drives tool calls directly via `ToolCapable` / `ToolSession`, or a **plan
+  pipeline** (`AgenticNodeExecutor`) with static/dynamic step sequences. This is the **tactics**.
 
 **The Architectural Core:** The engine is **pure Java** with **zero external dependencies**. Protocol handling (MCP),
 provider integrations (LLMs), persistence, and security (multi-tenancy via `ScopedValues`) are pluggable modules wired
@@ -76,7 +77,8 @@ agent providers, action executors, repositories, and configuration are resolved 
 The builder is the only place where deployment-specific behavior diverges: both CLI and server wire the LangChain4j
 provider for LLM access. The CLI additionally wires a local bash executor (`CLIActionExecutor`); the server wires
 `ServerActionExecutor` that dispatches `Action.Send` to any registered `ActionHandler` (falling back to MCP for
-unrecognized handlers) while rejecting `Action.Execute` (local bash), and delegates all components via CDI producers.
+unrecognized handlers) while rejecting `Action.Execute` (local bash) and skipping template resolution for
+agent-originated tool calls (`rawPayload`), and delegates all components via CDI producers.
 
 See [Core Developer Guide](developer-guide-core.md) for usage patterns.
 
@@ -306,7 +308,7 @@ flowchart TD
         subgraph core["hensu-core (HensuEnvironment)"]
             direction LR
             we(["Workflow\nExecutor"]) ~~~ ne(["Node\nExecutors"]) ~~~ pe(["Plan\nEngine"]) ~~~ ae(["Action\nExecutor"]) ~~~ re(["Rubric\nEngine"])
-            tr(["Tool\nRegistry"]) ~~~ ar(["Agent\nRegistry"]) ~~~ lp(["LLM\nPlanner"]) ~~~ el(["Execution\nListener"]) ~~~ wr(["Workflow\nRepository"]) ~~~ wsr(["WorkflowState\nRepository"])
+            tlr(["ToolLoop\nRunner"]) ~~~ tr(["Tool\nRegistry"]) ~~~ ar(["Agent\nRegistry"]) ~~~ lp(["LLM\nPlanner"]) ~~~ el(["Execution\nListener"]) ~~~ wr(["Workflow\nRepository"]) ~~~ wsr(["WorkflowState\nRepository"])
         end
     end
 
@@ -334,6 +336,7 @@ flowchart TD
     style pe fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
     style ae fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
     style re fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
+    style tlr fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
     style tr fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
     style ar fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
     style lp fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
@@ -370,11 +373,14 @@ Zero-dependency Java library. Contains:
   and `SynthesizeStepHandler`
 - `StaticPlanner` / `LlmPlanner` — Planner implementations: `StaticPlanner` resolves predefined
   DSL steps; `LlmPlanner` generates and revises plans dynamically via an LLM agent
-- `ToolRegistry` / `ToolDefinition` — Protocol-agnostic tool descriptors for MCP integration
+- `ToolCapable` / `ToolSession` — Narrow interface for agents that support tool sessions; `ToolSession` is call-scoped (not stateful on the agent) for `ParallelNodeExecutor` safety
+- `ToolLoopRunner` — Stateless driver dispatched from `AgentLifecycleRunner` when a node declares tools and the agent implements `ToolCapable`. Iterates the sealed `AgentResponse` hierarchy (`TextResponse` = done, `ToolRequest` = continue, `Error` = done), enforcing `AgentConfig.maxToolCalls` budget (default 10, counting executed calls). Cap exhaustion → one final summarization call → `SUCCESS` or hard `FAILURE`
+- `ToolCallResult` — Record `(toolName, success, output, error)` with `success()` / `failure()` factories
+- `ToolRegistry` / `ToolDefinition` — Protocol-agnostic tool descriptors used by agent-native tool loops, plan generation, and MCP integration
 - `RubricEngine` / `ScoreExtractingEvaluator` — Quality evaluation: reads `score` engine variable
   from context; accumulates feedback into `recommendation`; no JSON parsing
 - `EngineVariables` — SSOT for engine variable names (`score`, `approved`, `recommendation`)
-- `AgentLifecycleRunner` — Composition-based agent call: prompt enrichment → execution → output extraction
+- `AgentLifecycleRunner` — Composition-based agent call: prompt enrichment → execution → output extraction. When the node declares tools and the agent implements `ToolCapable`, dispatches to `ToolLoopRunner` for agent-native tool execution
 - `EngineVariablePromptEnricher` — Composite enricher running 7 injectors before each agent call:
   `FeedbackContextInjector` → `RubricPromptInjector` → `ScoreVariableInjector` →
   `ApprovalVariableInjector` → `RecommendationVariableInjector` → `WritesVariableInjector` →
@@ -405,7 +411,7 @@ Extends core with HTTP, MCP, and multi-tenancy:
 
 - `HensuEnvironmentProducer` — CDI producer using `HensuFactory.builder()`
 - `ServerConfiguration` — Delegates core components from `HensuEnvironment` via `@Produces @Singleton`
-- `ServerActionExecutor` — Send-action dispatcher (routes to registered handlers, falls back to MCP; rejects `Action.Execute`)
+- `ServerActionExecutor` — Send-action dispatcher (routes to registered handlers, falls back to MCP; rejects `Action.Execute`). Skips template resolution for agent-originated tool calls (`rawPayload`) to prevent context exfiltration from LLM-generated arguments
 - `WorkflowService` — Service layer facade: start/resume executions, snapshot management
 - `WorkflowRegistryService` — Push pipeline: wraps save in `WorkflowPushLock` and invokes `SubWorkflowGraphValidator` lazily resolving sub-workflow ids through the repository
 - `WorkflowPushLock` — Cluster-wide push mutex (`pg_advisory_xact_lock` with JVM `ReentrantLock` fallback) preventing concurrent pushes on different nodes from introducing cycles
@@ -421,7 +427,8 @@ Extends core with HTTP, MCP, and multi-tenancy:
 Bridges `hensu-core`'s `Agent` / `AgentProvider` abstraction with LangChain4j model implementations:
 
 - `LangChain4jProvider` — `AgentProvider` that creates `LangChain4jAgent` instances from `AgentConfig`
-- `LangChain4jAgent` — Wraps a LangChain4j `ChatModel` as a Hensu `Agent`
+- `LangChain4jAgent` — Wraps a LangChain4j `ChatModel` as a Hensu `Agent`; implements `ToolCapable` to support agent-native tool loops
+- `LangChain4jToolSession` — `ToolSession` implementation with multi-tool queue draining and `ReentrantLock`-guarded history (virtual-thread safe)
 - Programmatic `ChatModel` construction via builders (not CDI) – requires explicit native-image registration in `hensu-server` (`LangChain4j*NativeConfig` classes)
 
 Wired by both CLI and server via `HensuFactory.builder().agentProviders(List.of(new LangChain4jProvider()))`.
@@ -496,9 +503,29 @@ workflow("OrderProcessing") {
 }
 ```
 
-### 2. Micro-Plan (Node Level)
+### 2. Micro-Tactics (Node Level)
 
-Internal execution strategy within a node. Two modes:
+Internal execution strategy within a node. Three modes:
+
+**Agent-Native Tool Loop (Preferred):**
+
+When a node declares `tools` and its agent implements `ToolCapable`, `AgentLifecycleRunner` dispatches
+to `ToolLoopRunner`. The agent drives tool calls directly — the sealed `AgentResponse` hierarchy controls
+flow: `TextResponse` terminates with success, `ToolRequest` continues the loop, `Error` terminates with
+failure. Budget enforced by `AgentConfig.maxToolCalls` (default 10, counting executed calls not round-trips).
+Agent-originated tool arguments use `Action.Send(rawPayload=true)` to skip template resolution.
+
+```kotlin
+node("research-topic") {
+    agent = "researcher"
+    tools = listOf("search", "analyze", "summarize")
+    maxToolCalls = 15
+
+    prompt = "Research {topic} comprehensively"
+    onSuccess goto "publish"
+    onFailure goto "fallback"
+}
+```
 
 **Predefined Plan (Static):**
 
@@ -582,7 +609,35 @@ flowchart LR
 
 Any processor can short-circuit by returning a terminal `ExecutionResult`.
 
-**Inner Plan Loop** — what `node.execute()` runs for `StandardNode` via `AgenticNodeExecutor`:
+**Inner Execution** — what `node.execute()` runs for `StandardNode`. `AgentLifecycleRunner` selects the
+execution path: if the node declares tools and the agent implements `ToolCapable`, it dispatches to
+`ToolLoopRunner` (agent-native tool loop); otherwise it falls through to `AgenticNodeExecutor` (plan pipeline).
+
+**Tool Loop Path** (`ToolLoopRunner`):
+
+```mermaid
+flowchart LR
+    enrich(["PromptEnricher\n(7 injectors)"]) --> open(["openSession()\n(ToolCapable)"])
+    open --> call(["agent.call()\n→ AgentResponse"])
+    call -->|"TextResponse"| done(["SUCCESS\n(text = output)"])
+    call -->|"ToolRequest"| exec(["execute tools\n(Action.Send rawPayload)"])
+    exec -->|"budget ok"| call
+    exec -->|"cap exhausted"| summary(["final summarization\ncall"])
+    summary --> done
+    call -->|"Error"| fail(["FAILURE"])
+
+    style enrich fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
+    style open fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
+    style call fill:#2c2c2e, stroke:#0A84FF, color:#ebebf5, stroke-width:1px
+    style done fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
+    style exec fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
+    style summary fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
+    style fail fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
+
+    linkStyle default stroke:#0A84FF, stroke-width:1px
+```
+
+**Plan Pipeline Path** (`AgenticNodeExecutor`) — used when agent does not implement `ToolCapable` or node has no tools:
 
 ```mermaid
 flowchart LR
@@ -838,10 +893,10 @@ The unified architecture provides:
 5. **Non-Linear Graphs** — Condition-routed loops with bounded revise budgets, conditional branches, fork/join, parallel fan-out with consensus, backtracking
 6. **Structured Concurrency** — `StructuredTaskScope` (preview) for all parallel execution; no `ExecutorService`, no thread pool lifecycle
 7. **Rubric Evaluation** — Quality gates that score outputs and route on thresholds for self-correcting loops
-8. **Pause / Resume** — Workflows checkpoint at any node (including micro-plan step index via the active `Plan`) and resume; the lease protocol protects against data races when the owning node crashes
+8. **Pause / Resume** — Workflows checkpoint at any node (including plan step index for plan-pipeline nodes) and resume; tool-loop nodes re-enter from the node level. The lease protocol protects against data races when the owning node crashes
 9. **Distributed Recovery** — Heartbeat/sweeper lease protocol for crashed-node detection; atomic PostgreSQL `UPDATE…RETURNING` claim
 10. **Sub-Workflows** — Hierarchical composition via `SubWorkflowNode` with input/output mapping; `SubWorkflowGraphValidator` rejects cycles and dangling refs at push (under `WorkflowPushLock`); recursion bounded by `MAX_DEPTH = 16`; tenant isolation preserved across the boundary via `_tenant_id` propagation
-11. **Flexible Planning** — Static (predefined) or Dynamic (LLM-generated) execution plans within nodes
+11. **Flexible Execution** — Agent-native tool loop (`ToolLoopRunner` via `ToolCapable` / `ToolSession`) for direct tool driving, or plan pipeline with Static (predefined) / Dynamic (LLM-generated) step sequences
 12. **Human Review** — Checkpoints for manual approval at both plan and execution levels
 13. **Multi-Tenancy** — Java 25 `ScopedValues` for safe tenant context propagation and isolation
 14. **Storage in Core** — Repository interfaces with in-memory defaults; server delegates via CDI

--- a/hensu-cli/README.md
+++ b/hensu-cli/README.md
@@ -580,8 +580,9 @@ The CLI supports two action types that nodes can trigger during execution, imple
   directory). Commands are looked up by ID from a `CommandRegistry` – the DSL never
   specifies raw shell strings, keeping credentials out of workflow files.
 
-All action parameters support `{variable}` template syntax, resolved from the current
-workflow context at execution time.
+DSL-authored action parameters support `{variable}` template syntax, resolved from the
+current workflow context at execution time. Agent-originated tool calls bypass template
+resolution to prevent context exfiltration from LLM-generated arguments.
 
 ---
 

--- a/hensu-cli/src/main/java/io/hensu/cli/action/CLIActionExecutor.java
+++ b/hensu-cli/src/main/java/io/hensu/cli/action/CLIActionExecutor.java
@@ -124,10 +124,12 @@ public class CLIActionExecutor implements ActionExecutor {
 
         logger.info("Executing send action via handler: " + handlerId);
 
-        // Resolve template variables in payload values
-        Map<String, Object> resolvedPayload = resolvePayload(send.getPayload(), context);
+        Map<String, Object> effectivePayload =
+                send.isRawPayload()
+                        ? send.getPayload()
+                        : templateResolver.resolvePayload(send.getPayload(), context);
 
-        return handler.execute(resolvedPayload, context);
+        return handler.execute(effectivePayload, context);
     }
 
     private ActionResult executeCommand(Action.Execute exec, Map<String, Object> context) {
@@ -212,20 +214,5 @@ public class CLIActionExecutor implements ActionExecutor {
             }
         }
         return escaped;
-    }
-
-    /// Resolves template variables in payload string values.
-    private Map<String, Object> resolvePayload(
-            Map<String, Object> payload, Map<String, Object> context) {
-        Map<String, Object> resolved = new HashMap<>();
-        for (Map.Entry<String, Object> entry : payload.entrySet()) {
-            Object value = entry.getValue();
-            if (value instanceof String stringValue) {
-                resolved.put(entry.getKey(), templateResolver.resolve(stringValue, context));
-            } else {
-                resolved.put(entry.getKey(), value);
-            }
-        }
-        return resolved;
     }
 }

--- a/hensu-cli/src/test/java/io/hensu/cli/action/CLIActionExecutorTest.java
+++ b/hensu-cli/src/test/java/io/hensu/cli/action/CLIActionExecutorTest.java
@@ -27,7 +27,8 @@ class CLIActionExecutorTest {
         var handler = new PayloadCapturingHandler("template-handler");
         executor.registerHandler(handler);
 
-        Action.Send send = new Action.Send("template-handler", Map.of("message", "Hello {name}"));
+        Action.Send send =
+                new Action.Send("template-handler", Map.of("message", "Hello {name}"), false);
         Map<String, Object> context = Map.of("name", "World");
 
         executor.execute(send, context);
@@ -36,8 +37,21 @@ class CLIActionExecutorTest {
     }
 
     @Test
+    void shouldNotResolveTemplatesWhenRawPayloadTrue() {
+        var handler = new PayloadCapturingHandler("raw-handler");
+        executor.registerHandler(handler);
+
+        Action.Send send = new Action.Send("raw-handler", Map.of("message", "{name}"), true);
+        Map<String, Object> context = Map.of("name", "World");
+
+        executor.execute(send, context);
+
+        assertThat(handler.capturedPayload).containsEntry("message", "{name}");
+    }
+
+    @Test
     void shouldFailSendWhenHandlerNotRegistered() {
-        Action.Send send = new Action.Send("unknown-handler");
+        Action.Send send = new Action.Send("unknown-handler", Map.of(), false);
 
         ActionResult result = executor.execute(send, Map.of());
 

--- a/hensu-core/README.md
+++ b/hensu-core/README.md
@@ -10,7 +10,8 @@ The `hensu-core` module is the execution engine at the heart of Hensu. It provid
 - **Agent Abstraction** — Provider-agnostic AI agent interface with pluggable backends
 - **Rubric Engine** — Quality evaluation with weighted criteria, score-based routing, and LLM-based assessment
 - **Plan Engine** — Static or LLM-generated step-by-step plan execution within nodes
-- **Tool Registry** — Protocol-agnostic tool descriptors for plan generation and MCP integration
+- **Agent Tool Loop** — Native tool execution via `ToolCapable`/`ToolSession` with budget enforcement and sealed-hierarchy termination
+- **Tool Registry** — Protocol-agnostic tool descriptors for agent tool loops, plan generation, and MCP integration
 - **Human Review** — Optional or required review checkpoints at any workflow step
 - **Pause / Resume** — Phase-aware suspend and resume for long-running executions with out-of-band review support
 - **Action System** — Extensible action dispatch (send, execute) with pluggable executors
@@ -32,7 +33,7 @@ flowchart TD
         end
         subgraph nodes["Node Executors"]
             direction LR
-            std(["Standard"]) ~~~ par(["Parallel"]) ~~~ fj(["Fork/Join"]) ~~~ loop(["Loop"]) ~~~ act(["Action"]) ~~~ gen(["Generic"]) ~~~ sub(["SubWorkflow"])
+            std(["Standard"]) ~~~ par(["Parallel"]) ~~~ fj(["Fork/Join"]) ~~~ act(["Action"]) ~~~ gen(["Generic"]) ~~~ sub(["SubWorkflow"])
         end
         subgraph mid["Infrastructure"]
             direction LR
@@ -62,7 +63,6 @@ flowchart TD
     style std fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
     style par fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
     style fj fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
-    style loop fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
     style act fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
     style gen fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
     style sub fill:#2c2c2e, stroke:#48484a, color:#ebebf5, stroke-width:1px
@@ -221,8 +221,7 @@ flowchart LR
 
 ## Tool Registry
 
-Protocol-agnostic tool descriptors used by plan generation and execution. The core defines tool shapes; actual
-invocation happens through `ActionHandler` implementations at the application layer.
+Protocol-agnostic tool descriptors used by agent-native tool loops, plan generation, and MCP integration. The core defines tool shapes; actual invocation happens through `ActionExecutor` at the application layer.
 
 ```java
 // Register tools
@@ -244,8 +243,7 @@ registry.register(ToolDefinition.of("analyze", "Analyze data",
 | `ToolRegistry`        | Interface for tool registration and lookup                       |
 | `DefaultToolRegistry` | Thread-safe ConcurrentHashMap implementation                     |
 
-The server layer populates the tool registry from MCP server connections. Tools discovered via MCP become available for
-plan generation and execution.
+The server layer populates the tool registry from MCP server connections. Tools discovered via MCP become available for agent tool loops and plan generation. When a node declares tools and its agent implements `ToolCapable`, `ToolLoopRunner` resolves declared tool names against the registry, filters to the agent's declared subset, and passes full schemas into the tool session.
 
 ## Module Structure
 
@@ -261,9 +259,12 @@ hensu-core/src/main/java/io/hensu/core/
 │   ├── AgentProvider.java         # Provider interface for pluggable AI backends
 │   ├── AgentRegistry.java         # Agent lookup interface
 │   ├── DefaultAgentRegistry.java  # Thread-safe ConcurrentHashMap implementation
+│   ├── ToolCapable.java           # Narrow interface for agents that support tool sessions
+│   ├── ToolSession.java           # Call-scoped tool loop session (start/submit/compact/close)
 │   └── stub/
 │       ├── StubAgentProvider.java # Testing provider (priority 1000 when enabled)
 │       ├── StubAgent.java         # Mock agent returning stub responses
+│       ├── StubToolSession.java   # Scripted tool session for testing (---TURN--- syntax)
 │       └── StubResponseRegistry.java
 ├── execution/
 │   ├── WorkflowExecutor.java          # Main graph traversal engine (execute + executeFrom for resume)
@@ -275,6 +276,7 @@ hensu-core/src/main/java/io/hensu/core/
 │   │   ├── NodeResult.java                # Primary return type for all node executors
 │   │   ├── ExecutionContext.java           # Per-execution context carrier (state + tenant)
 │   │   ├── AgentLifecycleRunner.java      # Composition-based agent call: enrich → execute → extract
+│   │   ├── ToolLoopRunner.java           # Drives agent-native tool loop (budget, feed-back, sealed termination)
 │   │   ├── AgenticNodeExecutor.java       # Drives preparation + execution PlanPipelines for StandardNode
 │   │   ├── StandardNodeExecutor.java      # LLM prompt execution (no planning)
 │   │   ├── ParallelNodeExecutor.java      # Concurrent branch execution
@@ -375,6 +377,7 @@ hensu-core/src/main/java/io/hensu/core/
 │       └── ScoreExtractingEvaluator.java # Reads score engine variable from context; accumulates recommendation feedback
 ├── tool/                          # Protocol-agnostic tool descriptors
 │   ├── ToolDefinition.java        # Tool shape (name, params, return type)
+│   ├── ToolCallResult.java        # Tool execution result (success/failure factories, asText())
 │   ├── ToolRegistry.java          # Tool registration/lookup interface
 │   └── DefaultToolRegistry.java   # Thread-safe ConcurrentHashMap implementation
 ├── plan/                          # Agentic planning engine

--- a/hensu-core/src/main/java/io/hensu/core/HensuFactory.java
+++ b/hensu-core/src/main/java/io/hensu/core/HensuFactory.java
@@ -225,6 +225,7 @@ public final class HensuFactory {
                 workflowRepository,
                 workflowStateRepository,
                 null,
+                null,
                 null);
     }
 
@@ -243,7 +244,8 @@ public final class HensuFactory {
             WorkflowRepository workflowRepository,
             WorkflowStateRepository workflowStateRepository,
             Planner planner,
-            StepHandlerRegistry stepHandlerRegistry) {
+            StepHandlerRegistry stepHandlerRegistry,
+            ToolRegistry toolRegistry) {
         RubricRepository rubricRepository = createRubricRepository(config);
         RubricEngine rubricEngine =
                 new RubricEngine(rubricRepository, new ScoreExtractingEvaluator());
@@ -263,7 +265,8 @@ public final class HensuFactory {
                         lifecycleCoordinator,
                         actionExecutor,
                         templateResolver,
-                        workflowRepository);
+                        workflowRepository,
+                        toolRegistry);
 
         return new HensuEnvironment(
                 workflowExecutor,
@@ -763,7 +766,8 @@ public final class HensuFactory {
                     workflowRepository,
                     workflowStateRepository,
                     planner,
-                    builtStepHandlerRegistry);
+                    builtStepHandlerRegistry,
+                    toolRegistry != null ? toolRegistry : EMPTY_TOOL_REGISTRY);
         }
     }
 

--- a/hensu-core/src/main/java/io/hensu/core/agent/AgentConfig.java
+++ b/hensu-core/src/main/java/io/hensu/core/agent/AgentConfig.java
@@ -42,6 +42,7 @@ public final class AgentConfig {
     private final Double frequencyPenalty;
     private final Double presencePenalty;
     private final Long timeout;
+    private final Integer maxToolCalls;
 
     private AgentConfig(Builder builder) {
         this.id = Objects.requireNonNull(builder.id, "Agent ID required");
@@ -56,6 +57,7 @@ public final class AgentConfig {
         this.frequencyPenalty = builder.frequencyPenalty;
         this.presencePenalty = builder.presencePenalty;
         this.timeout = builder.timeout;
+        this.maxToolCalls = builder.maxToolCalls;
     }
 
     /// Returns the unique agent identifier.
@@ -142,6 +144,13 @@ public final class AgentConfig {
         return timeout;
     }
 
+    /// Returns the maximum number of tool calls allowed per execution.
+    ///
+    /// @return max tool calls limit, may be null (runner uses default of 10)
+    public Integer getMaxToolCalls() {
+        return maxToolCalls;
+    }
+
     /// Creates a new builder for constructing AgentConfig instances.
     ///
     /// @return a new builder instance, never null
@@ -165,6 +174,7 @@ public final class AgentConfig {
         private Double frequencyPenalty;
         private Double presencePenalty;
         private Long timeout;
+        private Integer maxToolCalls;
 
         private Builder() {}
 
@@ -276,6 +286,15 @@ public final class AgentConfig {
             return this;
         }
 
+        /// Sets the maximum number of tool calls allowed per execution.
+        ///
+        /// @param maxToolCalls the limit, may be null (runner uses default of 10)
+        /// @return this builder for chaining
+        public Builder maxToolCalls(Integer maxToolCalls) {
+            this.maxToolCalls = maxToolCalls;
+            return this;
+        }
+
         /// Builds an immutable AgentConfig instance.
         ///
         /// @return the constructed configuration, never null
@@ -300,7 +319,8 @@ public final class AgentConfig {
                 && Objects.equals(topP, that.topP)
                 && Objects.equals(frequencyPenalty, that.frequencyPenalty)
                 && Objects.equals(presencePenalty, that.presencePenalty)
-                && Objects.equals(timeout, that.timeout);
+                && Objects.equals(timeout, that.timeout)
+                && Objects.equals(maxToolCalls, that.maxToolCalls);
     }
 
     @Override
@@ -317,7 +337,8 @@ public final class AgentConfig {
                 topP,
                 frequencyPenalty,
                 presencePenalty,
-                timeout);
+                timeout,
+                maxToolCalls);
     }
 
     @Override

--- a/hensu-core/src/main/java/io/hensu/core/agent/AgentResponse.java
+++ b/hensu-core/src/main/java/io/hensu/core/agent/AgentResponse.java
@@ -2,6 +2,8 @@ package io.hensu.core.agent;
 
 import io.hensu.core.plan.PlannedStep;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -46,7 +48,10 @@ public sealed interface AgentResponse
 
         public TextResponse {
             Objects.requireNonNull(content, "content must not be null");
-            metadata = metadata != null ? Map.copyOf(metadata) : Map.of();
+            metadata =
+                    metadata != null
+                            ? Collections.unmodifiableMap(new HashMap<>(metadata))
+                            : Map.of();
             timestamp = timestamp != null ? timestamp : Instant.now();
         }
 
@@ -75,7 +80,10 @@ public sealed interface AgentResponse
 
         public ToolRequest {
             Objects.requireNonNull(toolName, "toolName must not be null");
-            arguments = arguments != null ? Map.copyOf(arguments) : Map.of();
+            arguments =
+                    arguments != null
+                            ? Collections.unmodifiableMap(new HashMap<>(arguments))
+                            : Map.of();
             reasoning = reasoning != null ? reasoning : "";
             timestamp = timestamp != null ? timestamp : Instant.now();
         }

--- a/hensu-core/src/main/java/io/hensu/core/agent/ToolCapable.java
+++ b/hensu-core/src/main/java/io/hensu/core/agent/ToolCapable.java
@@ -1,0 +1,23 @@
+package io.hensu.core.agent;
+
+import io.hensu.core.tool.ToolDefinition;
+import java.util.List;
+import java.util.Map;
+
+/// Capability interface for agents that support multi-turn tool execution.
+///
+/// Agents implement this alongside {@link Agent} to indicate they can
+/// participate in the tool loop driven by the engine's {@code ToolLoopRunner}.
+///
+/// @see ToolSession for the call-scoped session contract
+public interface ToolCapable {
+
+    /// Opens a new call-scoped tool session.
+    ///
+    /// @param prompt the resolved prompt text, not null
+    /// @param context execution context variables, not null
+    /// @param tools filtered tool definitions available to this agent, not null
+    /// @return a new session for driving the tool loop, never null
+    ToolSession openToolSession(
+            String prompt, Map<String, Object> context, List<ToolDefinition> tools);
+}

--- a/hensu-core/src/main/java/io/hensu/core/agent/ToolSession.java
+++ b/hensu-core/src/main/java/io/hensu/core/agent/ToolSession.java
@@ -1,0 +1,44 @@
+package io.hensu.core.agent;
+
+import io.hensu.core.tool.ToolCallResult;
+
+/// Call-scoped session for multi-turn tool interactions with an agent.
+///
+/// Each session encapsulates the message state for one tool loop execution.
+/// Sessions are call-scoped (not stateful on the agent) so that
+/// {@code ParallelNodeExecutor} fan-out can share one agent instance
+/// across branches without cross-branch bleed.
+///
+/// ### Termination Semantics
+/// The sealed {@link AgentResponse} hierarchy IS the signal:
+/// - {@link AgentResponse.TextResponse} — loop done, agent produced final answer
+/// - {@link AgentResponse.Error} — loop done, agent errored
+/// - {@link AgentResponse.ToolRequest} — loop continues (another tool call round)
+///
+/// @see ToolCapable#openToolSession for session creation
+public interface ToolSession {
+
+    /// Sends the initial prompt with tool definitions to the agent.
+    ///
+    /// @return first agent response (tool request or final answer), never null
+    AgentResponse start();
+
+    /// Feeds a tool execution result back to the agent.
+    ///
+    /// @param result the tool call outcome, not null
+    /// @return next agent response, never null
+    AgentResponse submit(ToolCallResult result);
+
+    /// Discards intermediate tool-call/result messages to free context window.
+    ///
+    /// Retains system message, original user prompt, and last assistant message.
+    /// Implementations may no-op if the session is already compact.
+    void compact();
+
+    /// Releases session resources and flushes the final prompt/answer pair
+    /// to the agent's shared conversation history (if applicable).
+    ///
+    /// Called in a finally block by the loop driver. Implementations that
+    /// hold no resources may no-op.
+    void close();
+}

--- a/hensu-core/src/main/java/io/hensu/core/agent/stub/StubAgent.java
+++ b/hensu-core/src/main/java/io/hensu/core/agent/stub/StubAgent.java
@@ -4,7 +4,11 @@ import io.hensu.core.agent.Agent;
 import io.hensu.core.agent.AgentConfig;
 import io.hensu.core.agent.AgentResponse;
 import io.hensu.core.agent.AgentResponse.TextResponse;
+import io.hensu.core.agent.ToolCapable;
+import io.hensu.core.agent.ToolSession;
+import io.hensu.core.tool.ToolDefinition;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -30,7 +34,7 @@ import java.util.logging.Logger;
 ///
 /// @see StubAgentProvider for enabling stub mode
 /// @see StubResponseRegistry for response configuration
-public class StubAgent implements Agent {
+public class StubAgent implements Agent, ToolCapable {
 
     private static final Logger logger = Logger.getLogger(StubAgent.class.getName());
 
@@ -57,6 +61,17 @@ public class StubAgent implements Agent {
     @Override
     public AgentConfig getConfig() {
         return config;
+    }
+
+    @Override
+    public ToolSession openToolSession(
+            String prompt, Map<String, Object> context, List<ToolDefinition> tools) {
+        String nodeId = context != null ? (String) context.get("current_node") : null;
+        String response = responseRegistry.getResponse(nodeId, id, context, prompt);
+        if (response == null) {
+            response = generateMockResponse(prompt, context);
+        }
+        return new StubToolSession(response);
     }
 
     /// Executes the agent by returning a configured or generated stub response.

--- a/hensu-core/src/main/java/io/hensu/core/agent/stub/StubToolSession.java
+++ b/hensu-core/src/main/java/io/hensu/core/agent/stub/StubToolSession.java
@@ -1,0 +1,76 @@
+package io.hensu.core.agent.stub;
+
+import io.hensu.core.agent.AgentResponse;
+import io.hensu.core.agent.ToolSession;
+import io.hensu.core.tool.ToolCallResult;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/// Scripted tool session for testing.
+///
+/// Parses the stub response text into turns separated by `---TURN---`.
+/// A turn starting with `[TOOL_CALL] toolName k=v k2=v2` produces a
+/// {@link AgentResponse.ToolRequest}; plain-text turns produce a
+/// {@link AgentResponse.TextResponse}. Script exhaustion on submit
+/// yields an {@link AgentResponse.Error}.
+class StubToolSession implements ToolSession {
+
+    private final String[] turns;
+    private int cursor = 0;
+
+    StubToolSession(String responseScript) {
+        this.turns = responseScript.split("---TURN---");
+    }
+
+    @Override
+    public AgentResponse start() {
+        return nextResponse();
+    }
+
+    @Override
+    public AgentResponse submit(ToolCallResult result) {
+        return nextResponse();
+    }
+
+    @Override
+    public void compact() {
+        // no-op: scripted session has no real context window
+    }
+
+    @Override
+    public void close() {
+        // no-op: no resources to release
+    }
+
+    private AgentResponse nextResponse() {
+        if (cursor >= turns.length) {
+            return AgentResponse.Error.of("Stub tool session script exhausted");
+        }
+
+        String turn = turns[cursor++].trim();
+
+        if (turn.startsWith("[TOOL_CALL]")) {
+            return parseToolCall(turn);
+        }
+
+        return AgentResponse.TextResponse.of(turn);
+    }
+
+    private AgentResponse.ToolRequest parseToolCall(String turn) {
+        // Format: [TOOL_CALL] toolName k=v k2=v2
+        String content = turn.substring("[TOOL_CALL]".length()).trim();
+        String[] parts = content.split("\\s+");
+
+        String toolName = parts.length > 0 ? parts[0] : "unknown";
+        Map<String, Object> arguments = new LinkedHashMap<>();
+
+        for (int i = 1; i < parts.length; i++) {
+            int eq = parts[i].indexOf('=');
+            if (eq > 0) {
+                arguments.put(parts[i].substring(0, eq), parts[i].substring(eq + 1));
+            }
+        }
+
+        return AgentResponse.ToolRequest.of(toolName, arguments);
+    }
+}

--- a/hensu-core/src/main/java/io/hensu/core/execution/WorkflowExecutor.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/WorkflowExecutor.java
@@ -11,6 +11,7 @@ import io.hensu.core.execution.result.ExitStatus;
 import io.hensu.core.rubric.RubricEngine;
 import io.hensu.core.state.HensuState;
 import io.hensu.core.template.TemplateResolver;
+import io.hensu.core.tool.ToolRegistry;
 import io.hensu.core.workflow.Workflow;
 import io.hensu.core.workflow.WorkflowRepository;
 import io.hensu.core.workflow.node.Node;
@@ -62,6 +63,7 @@ public class WorkflowExecutor {
     private final TemplateResolver templateResolver;
     private final ActionExecutor actionExecutor;
     private final WorkflowRepository workflowRepository;
+    private final ToolRegistry toolRegistry;
     private final NodeLifecycleCoordinator lifecycleCoordinator;
 
     /// Creates a workflow executor with all dependencies.
@@ -73,6 +75,7 @@ public class WorkflowExecutor {
     /// @param actionExecutor        executor for executable actions, may be null
     /// @param templateResolver      resolver for `{variable}` syntax in prompts, not null
     /// @param workflowRepository    repository for loading sub-workflow definitions, may be null
+    /// @param toolRegistry          registry for discovering available tools, may be null
     public WorkflowExecutor(
             NodeExecutorRegistry nodeExecutorRegistry,
             AgentRegistry agentRegistry,
@@ -80,7 +83,8 @@ public class WorkflowExecutor {
             NodeLifecycleCoordinator lifecycleCoordinator,
             ActionExecutor actionExecutor,
             TemplateResolver templateResolver,
-            WorkflowRepository workflowRepository) {
+            WorkflowRepository workflowRepository,
+            ToolRegistry toolRegistry) {
         this.nodeExecutorRegistry = nodeExecutorRegistry;
         this.agentRegistry = agentRegistry;
         this.rubricEngine = rubricEngine;
@@ -90,6 +94,7 @@ public class WorkflowExecutor {
         this.actionExecutor = actionExecutor;
         this.templateResolver = templateResolver;
         this.workflowRepository = workflowRepository;
+        this.toolRegistry = toolRegistry;
     }
 
     /// Executes a workflow without observability listener.
@@ -243,6 +248,7 @@ public class WorkflowExecutor {
                 .actionExecutor(actionExecutor)
                 .workflowRepository(workflowRepository)
                 .rubricEngine(rubricEngine)
+                .toolRegistry(toolRegistry)
                 .build();
     }
 

--- a/hensu-core/src/main/java/io/hensu/core/execution/action/Action.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/action/Action.java
@@ -1,5 +1,7 @@
 package io.hensu.core.execution.action;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /// Actions that can be executed when an action node is reached.
@@ -38,21 +40,21 @@ public abstract sealed class Action {
     public static final class Send extends Action {
         private final String handlerId;
         private final Map<String, Object> payload;
+        private final boolean rawPayload;
 
-        /// Creates a send action with no payload.
-        ///
-        /// @param handlerId the registered action handler ID, not null or blank
-        public Send(String handlerId) {
-            this(handlerId, Map.of());
-        }
-
-        /// Creates a send action with payload data.
+        /// Creates a send action with payload and raw-payload flag.
         ///
         /// @param handlerId the registered action handler ID, not null or blank
         /// @param payload action-specific data passed to the handler, not null
-        public Send(String handlerId, Map<String, Object> payload) {
+        /// @param rawPayload `true` for agent-originated payloads that must NOT be
+        ///        template-resolved; `false` for DSL-authored payloads
+        public Send(String handlerId, Map<String, Object> payload, boolean rawPayload) {
             this.handlerId = handlerId;
-            this.payload = payload != null ? Map.copyOf(payload) : Map.of();
+            this.payload =
+                    payload != null
+                            ? Collections.unmodifiableMap(new HashMap<>(payload))
+                            : Map.of();
+            this.rawPayload = rawPayload;
         }
 
         /// Returns the action handler ID.
@@ -67,6 +69,13 @@ public abstract sealed class Action {
         /// @return immutable payload map, never null (may be empty)
         public Map<String, Object> getPayload() {
             return payload;
+        }
+
+        /// Returns whether this payload is agent-originated and must skip template resolution.
+        ///
+        /// @return `true` if the payload should not be template-resolved
+        public boolean isRawPayload() {
+            return rawPayload;
         }
     }
 
@@ -98,12 +107,11 @@ public abstract sealed class Action {
     public static Action fromString(String str) {
         if (str.startsWith("send:")) {
             String handlerId = str.substring("send:".length()).trim();
-            return new Send(handlerId);
+            return new Send(handlerId, Map.of(), false);
         } else if (str.startsWith("exec:")) {
             return new Execute(str.substring("exec:".length()).trim());
         } else {
-            // Default: treat as send action with message payload
-            return new Send("default", Map.of("message", str));
+            return new Send("default", Map.of("message", str), false);
         }
     }
 }

--- a/hensu-core/src/main/java/io/hensu/core/execution/executor/AgentLifecycleRunner.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/executor/AgentLifecycleRunner.java
@@ -63,13 +63,28 @@ final class AgentLifecycleRunner {
 
         logger.info("Executing agent: " + agentId + " for " + eventSourceId);
 
-        // 3. Listener events + execution
+        // 3. Tool loop engagement: agent declares tools → delegate to ToolLoopRunner
+        if (agent.getConfig() != null && !agent.getConfig().getTools().isEmpty()) {
+            ExecutionListener listener = ctx.getListener();
+            listener.onAgentStart(eventSourceId, agentId, resolved);
+            NodeResult result =
+                    ToolLoopRunner.execute(eventSourceId, agentId, resolved, agent, ctx);
+            AgentResponse syntheticResponse =
+                    result.getStatus() == io.hensu.core.execution.result.ResultStatus.SUCCESS
+                            ? AgentResponse.TextResponse.of(
+                                    String.valueOf(result.getOutput()), result.getMetadata())
+                            : AgentResponse.Error.of(String.valueOf(result.getOutput()));
+            listener.onAgentComplete(eventSourceId, agentId, syntheticResponse);
+            return result;
+        }
+
+        // 4. Standard path: no tools declared
         ExecutionListener listener = ctx.getListener();
         listener.onAgentStart(eventSourceId, agentId, resolved);
         AgentResponse response = agent.execute(resolved, ctx.getState().getContext());
         listener.onAgentComplete(eventSourceId, agentId, response);
 
-        // 4. Response conversion
+        // 5. Response conversion
         return toNodeResult(response);
     }
 

--- a/hensu-core/src/main/java/io/hensu/core/execution/executor/ExecutionContext.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/executor/ExecutionContext.java
@@ -8,6 +8,7 @@ import io.hensu.core.execution.parallel.BranchExecutionConfig;
 import io.hensu.core.rubric.RubricEngine;
 import io.hensu.core.state.HensuState;
 import io.hensu.core.template.TemplateResolver;
+import io.hensu.core.tool.ToolRegistry;
 import io.hensu.core.workflow.Workflow;
 import io.hensu.core.workflow.WorkflowRepository;
 
@@ -55,6 +56,7 @@ public final class ExecutionContext {
     private final ActionExecutor actionExecutor;
     private final RubricEngine rubricEngine;
     private final WorkflowRepository workflowRepository;
+    private final ToolRegistry toolRegistry;
 
     private ExecutionContext(Builder builder) {
         this.state = builder.state;
@@ -68,6 +70,7 @@ public final class ExecutionContext {
         this.actionExecutor = builder.actionExecutor;
         this.rubricEngine = builder.rubricEngine;
         this.workflowRepository = builder.workflowRepository;
+        this.toolRegistry = builder.toolRegistry;
     }
 
     /// Returns the current workflow execution state.
@@ -144,6 +147,13 @@ public final class ExecutionContext {
         return workflowRepository;
     }
 
+    /// Returns the tool registry for resolving available tools.
+    ///
+    /// @return tool registry, or null if not configured
+    public ToolRegistry getToolRegistry() {
+        return toolRegistry;
+    }
+
     /// Returns the branch execution configuration, if executing inside a parallel branch.
     ///
     /// Non-null only during branch execution within {@code ParallelNodeExecutor}.
@@ -183,6 +193,7 @@ public final class ExecutionContext {
                 .actionExecutor(this.actionExecutor)
                 .rubricEngine(this.rubricEngine)
                 .workflowRepository(this.workflowRepository)
+                .toolRegistry(this.toolRegistry)
                 .build();
     }
 
@@ -206,6 +217,7 @@ public final class ExecutionContext {
                 .actionExecutor(this.actionExecutor)
                 .rubricEngine(this.rubricEngine)
                 .workflowRepository(this.workflowRepository)
+                .toolRegistry(this.toolRegistry)
                 .build();
     }
 
@@ -229,6 +241,7 @@ public final class ExecutionContext {
                 .actionExecutor(this.actionExecutor)
                 .rubricEngine(this.rubricEngine)
                 .workflowRepository(this.workflowRepository)
+                .toolRegistry(this.toolRegistry)
                 .build();
     }
 
@@ -249,6 +262,7 @@ public final class ExecutionContext {
         private ActionExecutor actionExecutor;
         private RubricEngine rubricEngine;
         private WorkflowRepository workflowRepository;
+        private ToolRegistry toolRegistry;
 
         private Builder() {}
 
@@ -304,6 +318,11 @@ public final class ExecutionContext {
 
         public Builder workflowRepository(WorkflowRepository workflowRepository) {
             this.workflowRepository = workflowRepository;
+            return this;
+        }
+
+        public Builder toolRegistry(ToolRegistry toolRegistry) {
+            this.toolRegistry = toolRegistry;
             return this;
         }
 

--- a/hensu-core/src/main/java/io/hensu/core/execution/executor/ToolLoopRunner.java
+++ b/hensu-core/src/main/java/io/hensu/core/execution/executor/ToolLoopRunner.java
@@ -1,0 +1,219 @@
+package io.hensu.core.execution.executor;
+
+import io.hensu.core.agent.Agent;
+import io.hensu.core.agent.AgentResponse;
+import io.hensu.core.agent.ToolCapable;
+import io.hensu.core.agent.ToolSession;
+import io.hensu.core.execution.action.Action;
+import io.hensu.core.execution.action.ActionExecutor;
+import io.hensu.core.execution.result.ResultStatus;
+import io.hensu.core.tool.ToolCallResult;
+import io.hensu.core.tool.ToolDefinition;
+import io.hensu.core.tool.ToolRegistry;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+/// Stateless driver for the agent-native tool execution loop.
+///
+/// Dispatched from {@link AgentLifecycleRunner} when an agent declares tools
+/// and implements {@link ToolCapable}. Resolves tools from the
+/// {@link ToolRegistry}, opens a {@link ToolSession}, and iterates
+/// tool-request/tool-result rounds until the agent emits a terminal response
+/// or the tool call budget is exhausted.
+///
+/// @implNote Package-private, stateless, no instances. Safe to call from any
+/// thread including Virtual Threads.
+final class ToolLoopRunner {
+
+    private static final Logger logger = Logger.getLogger(ToolLoopRunner.class.getName());
+    private static final int DEFAULT_MAX_TOOL_CALLS = 10;
+
+    private ToolLoopRunner() {}
+
+    /// Executes the full tool loop for an agent.
+    ///
+    /// @param eventSourceId  identifier for listener events
+    /// @param agentId        identifier of the agent
+    /// @param resolvedPrompt prompt with placeholders resolved and enriched
+    /// @param agent          the resolved agent instance
+    /// @param ctx            execution context carrying state and services
+    /// @return node result, never null
+    static NodeResult execute(
+            String eventSourceId,
+            String agentId,
+            String resolvedPrompt,
+            Agent agent,
+            ExecutionContext ctx) {
+
+        if (!(agent instanceof ToolCapable toolCapable)) {
+            return new NodeResult(
+                    ResultStatus.FAILURE,
+                    "Agent '" + agentId + "' declares tools but does not implement ToolCapable",
+                    Map.of());
+        }
+
+        ActionExecutor actionExecutor = ctx.getActionExecutor();
+        if (actionExecutor == null) {
+            return new NodeResult(
+                    ResultStatus.FAILURE,
+                    "Agent '" + agentId + "' declares tools but no ActionExecutor is configured",
+                    Map.of());
+        }
+
+        List<ToolDefinition> availableTools = resolveTools(agent, ctx);
+        if (availableTools == null) {
+            List<String> declared = agent.getConfig().getTools();
+            ToolRegistry registry = ctx.getToolRegistry();
+            List<String> available =
+                    registry != null
+                            ? registry.all().stream().map(ToolDefinition::name).toList()
+                            : List.of();
+            return new NodeResult(
+                    ResultStatus.FAILURE,
+                    "Unresolvable tools for agent '"
+                            + agentId
+                            + "': declared="
+                            + declared
+                            + ", available="
+                            + available,
+                    Map.of());
+        }
+
+        int maxToolCalls =
+                agent.getConfig().getMaxToolCalls() != null
+                        ? agent.getConfig().getMaxToolCalls()
+                        : DEFAULT_MAX_TOOL_CALLS;
+
+        ToolSession session =
+                toolCapable.openToolSession(
+                        resolvedPrompt, ctx.getState().getContext(), availableTools);
+
+        try {
+            AgentResponse response = session.start();
+            int toolCallCount = 0;
+
+            while (response instanceof AgentResponse.ToolRequest toolRequest) {
+                // Budget check — count EXECUTED tool calls, not rounds
+                if (toolCallCount >= maxToolCalls) {
+                    session.compact();
+                    ToolCallResult exhaustion =
+                            ToolCallResult.failure(
+                                    toolRequest.toolName(),
+                                    "Tool call budget exhausted ("
+                                            + toolCallCount
+                                            + "/"
+                                            + maxToolCalls
+                                            + "). Provide your final answer based on the tool results received so far.");
+                    response = session.submit(exhaustion);
+
+                    if (response instanceof AgentResponse.ToolRequest) {
+                        return new NodeResult(
+                                ResultStatus.FAILURE,
+                                "Agent continued requesting tools after budget exhaustion ("
+                                        + maxToolCalls
+                                        + "/"
+                                        + maxToolCalls
+                                        + ")",
+                                Map.of());
+                    }
+                    break;
+                }
+
+                ToolCallResult result =
+                        executeTool(toolRequest, availableTools, actionExecutor, ctx);
+                toolCallCount++;
+                response = session.submit(result);
+            }
+
+            return toNodeResult(response);
+
+        } finally {
+            session.close();
+        }
+    }
+
+    private static List<ToolDefinition> resolveTools(Agent agent, ExecutionContext ctx) {
+        List<String> declaredNames = agent.getConfig().getTools();
+        ToolRegistry registry = ctx.getToolRegistry();
+
+        if (registry == null) {
+            return null;
+        }
+
+        List<ToolDefinition> allTools = registry.all();
+        Map<String, ToolDefinition> byName =
+                allTools.stream()
+                        .collect(Collectors.toMap(ToolDefinition::name, t -> t, (a, _) -> a));
+
+        List<ToolDefinition> resolved = declaredNames.stream().map(byName::get).toList();
+
+        if (resolved.stream().anyMatch(Objects::isNull)) {
+            return null;
+        }
+
+        return resolved;
+    }
+
+    private static ToolCallResult executeTool(
+            AgentResponse.ToolRequest toolRequest,
+            List<ToolDefinition> availableTools,
+            ActionExecutor actionExecutor,
+            ExecutionContext ctx) {
+
+        String toolName = toolRequest.toolName();
+
+        // Unknown tool (hallucination) — feed back, don't hard-fail
+        boolean known = availableTools.stream().anyMatch(t -> t.name().equals(toolName));
+        if (!known) {
+            List<String> available = availableTools.stream().map(ToolDefinition::name).toList();
+            logger.warning(
+                    "Agent requested unknown tool '" + toolName + "', available: " + available);
+            return ToolCallResult.failure(
+                    toolName, "Unknown tool '" + toolName + "', available: " + available);
+        }
+
+        try {
+            Map<String, Object> arguments =
+                    (Map<String, Object>) (Map<?, ?>) toolRequest.arguments();
+            Action.Send send = new Action.Send(toolName, arguments, true);
+            ActionExecutor.ActionResult actionResult =
+                    actionExecutor.execute(send, ctx.getState().getContext());
+
+            if (actionResult.success()) {
+                return ToolCallResult.success(
+                        toolName,
+                        actionResult.output() != null ? actionResult.output().toString() : "");
+            } else {
+                return ToolCallResult.failure(toolName, actionResult.message());
+            }
+        } catch (Exception e) {
+            logger.warning("Tool execution failed for '" + toolName + "': " + e.getMessage());
+            return ToolCallResult.failure(toolName, "Execution error: " + e.getMessage());
+        }
+    }
+
+    private static NodeResult toNodeResult(AgentResponse response) {
+        return switch (response) {
+            case AgentResponse.TextResponse t ->
+                    new NodeResult(ResultStatus.SUCCESS, t.content(), t.metadata());
+            case AgentResponse.Error e ->
+                    new NodeResult(
+                            ResultStatus.FAILURE,
+                            e.message(),
+                            Map.of("errorType", e.errorType().name()));
+            case AgentResponse.ToolRequest _ ->
+                    new NodeResult(
+                            ResultStatus.FAILURE,
+                            "Unexpected ToolRequest after loop exit",
+                            Map.of());
+            case AgentResponse.PlanProposal p ->
+                    new NodeResult(
+                            ResultStatus.SUCCESS,
+                            "Plan with " + p.steps().size() + " steps",
+                            Map.of("steps", p.steps()));
+        };
+    }
+}

--- a/hensu-core/src/main/java/io/hensu/core/plan/PlanStepAction.java
+++ b/hensu-core/src/main/java/io/hensu/core/plan/PlanStepAction.java
@@ -1,5 +1,7 @@
 package io.hensu.core.plan;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -32,7 +34,10 @@ public sealed interface PlanStepAction permits PlanStepAction.ToolCall, PlanStep
             if (toolName.isBlank()) {
                 throw new IllegalArgumentException("toolName must not be blank");
             }
-            arguments = arguments != null ? Map.copyOf(arguments) : Map.of();
+            arguments =
+                    arguments != null
+                            ? Collections.unmodifiableMap(new HashMap<>(arguments))
+                            : Map.of();
         }
     }
 

--- a/hensu-core/src/main/java/io/hensu/core/plan/ToolCallStepHandler.java
+++ b/hensu-core/src/main/java/io/hensu/core/plan/ToolCallStepHandler.java
@@ -39,7 +39,7 @@ public class ToolCallStepHandler implements StepHandler<PlanStepAction.ToolCall>
     public StepResult handle(
             PlannedStep step, PlanStepAction.ToolCall action, Map<String, Object> context) {
         Instant start = Instant.now();
-        Action mcpAction = new Action.Send(action.toolName(), action.arguments());
+        Action mcpAction = new Action.Send(action.toolName(), action.arguments(), false);
         ActionResult result = actionExecutor.execute(mcpAction, context);
         Duration duration = Duration.between(start, Instant.now());
 

--- a/hensu-core/src/main/java/io/hensu/core/template/TemplateResolver.java
+++ b/hensu-core/src/main/java/io/hensu/core/template/TemplateResolver.java
@@ -1,8 +1,30 @@
 package io.hensu.core.template;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /// Resolves template variables in strings. Pure utility, no dependencies.
 public interface TemplateResolver {
     String resolve(String template, Map<String, Object> context);
+
+    /// Resolves template variables in all string values of a payload map.
+    ///
+    /// Non-string values are passed through unchanged.
+    ///
+    /// @param payload the payload map with potential template placeholders
+    /// @param context variable bindings for resolution
+    /// @return new map with string values resolved, never null
+    default Map<String, Object> resolvePayload(
+            Map<String, Object> payload, Map<String, Object> context) {
+        Map<String, Object> resolved = new HashMap<>();
+        for (Map.Entry<String, Object> entry : payload.entrySet()) {
+            Object value = entry.getValue();
+            if (value instanceof String stringValue) {
+                resolved.put(entry.getKey(), resolve(stringValue, context));
+            } else {
+                resolved.put(entry.getKey(), value);
+            }
+        }
+        return resolved;
+    }
 }

--- a/hensu-core/src/main/java/io/hensu/core/tool/ToolCallResult.java
+++ b/hensu-core/src/main/java/io/hensu/core/tool/ToolCallResult.java
@@ -1,0 +1,41 @@
+package io.hensu.core.tool;
+
+import java.util.Objects;
+
+/// Result of executing a tool call, fed back to the agent for the next round.
+///
+/// @param toolName name of the tool that was invoked, not null
+/// @param success whether the invocation succeeded
+/// @param output tool output on success, may be null
+/// @param error error message on failure, may be null
+public record ToolCallResult(String toolName, boolean success, String output, String error) {
+
+    public ToolCallResult {
+        Objects.requireNonNull(toolName, "toolName must not be null");
+    }
+
+    /// Creates a successful tool call result.
+    ///
+    /// @param toolName tool that was invoked, not null
+    /// @param output tool output text, not null
+    /// @return successful result, never null
+    public static ToolCallResult success(String toolName, String output) {
+        return new ToolCallResult(toolName, true, output, null);
+    }
+
+    /// Creates a failed tool call result.
+    ///
+    /// @param toolName tool that was invoked, not null
+    /// @param error error description, not null
+    /// @return failure result, never null
+    public static ToolCallResult failure(String toolName, String error) {
+        return new ToolCallResult(toolName, false, null, error);
+    }
+
+    /// Returns the output on success or "ERROR: " + error on failure.
+    ///
+    /// @return text representation for feeding back to the agent, never null
+    public String asText() {
+        return success ? (output != null ? output : "") : "ERROR: " + (error != null ? error : "");
+    }
+}

--- a/hensu-core/src/test/java/io/hensu/core/execution/WorkflowExecutorActionNodeTest.java
+++ b/hensu-core/src/test/java/io/hensu/core/execution/WorkflowExecutorActionNodeTest.java
@@ -38,6 +38,7 @@ class WorkflowExecutorActionNodeTest extends WorkflowExecutorTestBase {
                         createCoordinator(registry, ReviewHandler.AUTO_APPROVE, rubricEngine),
                         mockActionExecutor,
                         null,
+                        null,
                         null);
     }
 

--- a/hensu-core/src/test/java/io/hensu/core/execution/WorkflowExecutorGenericNodeTest.java
+++ b/hensu-core/src/test/java/io/hensu/core/execution/WorkflowExecutorGenericNodeTest.java
@@ -36,6 +36,7 @@ class WorkflowExecutorGenericNodeTest extends WorkflowExecutorTestBase {
                                 genericRegistry, ReviewHandler.AUTO_APPROVE, rubricEngine),
                         null,
                         null,
+                        null,
                         null);
     }
 

--- a/hensu-core/src/test/java/io/hensu/core/execution/WorkflowExecutorHumanReviewTest.java
+++ b/hensu-core/src/test/java/io/hensu/core/execution/WorkflowExecutorHumanReviewTest.java
@@ -44,6 +44,7 @@ class WorkflowExecutorHumanReviewTest extends WorkflowExecutorTestBase {
                         createCoordinator(registry, mockReviewHandler, rubricEngine),
                         null,
                         new SimpleTemplateResolver(),
+                        null,
                         null);
     }
 
@@ -240,6 +241,7 @@ class WorkflowExecutorHumanReviewTest extends WorkflowExecutorTestBase {
                                         new DefaultNodeExecutorRegistry(),
                                         agentRegistry,
                                         rubricEngine,
+                                        null,
                                         null,
                                         null,
                                         null,

--- a/hensu-core/src/test/java/io/hensu/core/execution/WorkflowExecutorSubWorkflowTest.java
+++ b/hensu-core/src/test/java/io/hensu/core/execution/WorkflowExecutorSubWorkflowTest.java
@@ -52,7 +52,8 @@ class WorkflowExecutorSubWorkflowTest extends WorkflowExecutorTestBase {
                         createCoordinator(registry, ReviewHandler.AUTO_APPROVE, rubricEngine),
                         null,
                         new SimpleTemplateResolver(),
-                        repository);
+                        repository,
+                        null);
     }
 
     @Test
@@ -339,6 +340,7 @@ class WorkflowExecutorSubWorkflowTest extends WorkflowExecutorTestBase {
                         agentRegistry,
                         rubricEngine,
                         createCoordinator(registry, ReviewHandler.AUTO_APPROVE, rubricEngine),
+                        null,
                         null,
                         null,
                         null);

--- a/hensu-core/src/test/java/io/hensu/core/execution/WorkflowExecutorTestBase.java
+++ b/hensu-core/src/test/java/io/hensu/core/execution/WorkflowExecutorTestBase.java
@@ -51,6 +51,7 @@ abstract class WorkflowExecutorTestBase {
                         createCoordinator(registry, ReviewHandler.AUTO_APPROVE, rubricEngine),
                         null,
                         new SimpleTemplateResolver(),
+                        null,
                         null);
     }
 

--- a/hensu-core/src/test/java/io/hensu/core/execution/executor/ToolLoopRunnerTest.java
+++ b/hensu-core/src/test/java/io/hensu/core/execution/executor/ToolLoopRunnerTest.java
@@ -1,0 +1,373 @@
+package io.hensu.core.execution.executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.hensu.core.agent.*;
+import io.hensu.core.agent.stub.StubAgent;
+import io.hensu.core.execution.ExecutionListener;
+import io.hensu.core.execution.action.Action;
+import io.hensu.core.execution.action.ActionExecutor;
+import io.hensu.core.execution.action.ActionExecutor.ActionResult;
+import io.hensu.core.execution.result.ExecutionHistory;
+import io.hensu.core.execution.result.ExitStatus;
+import io.hensu.core.execution.result.ResultStatus;
+import io.hensu.core.state.HensuState;
+import io.hensu.core.tool.DefaultToolRegistry;
+import io.hensu.core.tool.ToolDefinition;
+import io.hensu.core.tool.ToolRegistry;
+import io.hensu.core.workflow.Workflow;
+import io.hensu.core.workflow.node.EndNode;
+import io.hensu.core.workflow.node.StandardNode;
+import io.hensu.core.workflow.transition.SuccessTransition;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ToolLoopRunnerTest {
+
+    private ActionExecutor mockActionExecutor;
+    private ToolRegistry toolRegistry;
+
+    @BeforeEach
+    void setUp() {
+        mockActionExecutor = mock(ActionExecutor.class);
+        toolRegistry = new DefaultToolRegistry();
+        ToolDefinition searchTool =
+                ToolDefinition.of(
+                        "search",
+                        "Search for information",
+                        List.of(
+                                ToolDefinition.ParameterDef.required(
+                                        "query", "string", "Search query")));
+        toolRegistry.register(searchTool);
+    }
+
+    @Nested
+    class HappyPath {
+
+        @Test
+        void shouldExecuteToolAndReturnFinalResponse() {
+            when(mockActionExecutor.execute(any(Action.class), any()))
+                    .thenReturn(ActionResult.success("Found results", "search results here"));
+
+            AgentConfig config = agentConfig(List.of("search"));
+            StubAgent agent = new StubAgent("test-agent", config);
+
+            registerStubResponse(
+                    agent,
+                    "[TOOL_CALL] search query=test\n---TURN---\nFinal answer based on search");
+
+            ExecutionContext ctx = buildContext(config, agent);
+
+            NodeResult result =
+                    ToolLoopRunner.execute("node1", "test-agent", "Find info", agent, ctx);
+
+            assertThat(result.getStatus()).isEqualTo(ResultStatus.SUCCESS);
+            assertThat(result.getOutput().toString()).isEqualTo("Final answer based on search");
+            verify(mockActionExecutor).execute(any(Action.Send.class), any());
+        }
+
+        @Test
+        void shouldHandleMultipleToolRounds() {
+            when(mockActionExecutor.execute(any(Action.class), any()))
+                    .thenReturn(ActionResult.success("ok", "result1"))
+                    .thenReturn(ActionResult.success("ok", "result2"));
+
+            AgentConfig config = agentConfig(List.of("search"));
+            StubAgent agent = new StubAgent("test-agent", config);
+
+            registerStubResponse(
+                    agent,
+                    """
+                            [TOOL_CALL] search query=first
+                            ---TURN---
+                            [TOOL_CALL] search query=second
+                            ---TURN---
+                            Combined answer""");
+
+            ExecutionContext ctx = buildContext(config, agent);
+
+            NodeResult result =
+                    ToolLoopRunner.execute("node1", "test-agent", "Multi search", agent, ctx);
+
+            assertThat(result.getStatus()).isEqualTo(ResultStatus.SUCCESS);
+            assertThat(result.getOutput().toString()).isEqualTo("Combined answer");
+            verify(mockActionExecutor, times(2)).execute(any(Action.Send.class), any());
+        }
+    }
+
+    @Nested
+    class CapExhaustion {
+
+        @Test
+        void shouldSucceedWhenModelCooperatesAfterCapExhaustion() {
+            when(mockActionExecutor.execute(any(Action.class), any()))
+                    .thenReturn(ActionResult.success("ok", "tool output"));
+
+            AgentConfig config =
+                    AgentConfig.builder()
+                            .id("test-agent")
+                            .role("tester")
+                            .model("stub")
+                            .tools(List.of("search"))
+                            .maxToolCalls(1)
+                            .build();
+
+            StubAgent agent = new StubAgent("test-agent", config);
+            // First turn: tool call (counts as 1, hitting cap)
+            // After cap exhaustion feedback, stub returns final text
+            registerStubResponse(
+                    agent,
+                    """
+                            [TOOL_CALL] search query=test
+                            ---TURN---
+                            Final answer after budget warning""");
+
+            ExecutionContext ctx = buildContext(config, agent);
+
+            NodeResult result = ToolLoopRunner.execute("node1", "test-agent", "Search", agent, ctx);
+
+            assertThat(result.getStatus()).isEqualTo(ResultStatus.SUCCESS);
+            assertThat(result.getOutput().toString())
+                    .isEqualTo("Final answer after budget warning");
+        }
+
+        @Test
+        void shouldFailWhenModelIgnoresBudgetWarning() {
+            when(mockActionExecutor.execute(any(Action.class), any()))
+                    .thenReturn(ActionResult.success("ok", "tool output"));
+
+            AgentConfig config =
+                    AgentConfig.builder()
+                            .id("test-agent")
+                            .role("tester")
+                            .model("stub")
+                            .tools(List.of("search"))
+                            .maxToolCalls(1)
+                            .build();
+
+            StubAgent agent = new StubAgent("test-agent", config);
+            // First: tool call (hits cap after execution), then after cap-exhaustion
+            // feedback the stub still tries another tool call instead of answering
+            registerStubResponse(
+                    agent,
+                    """
+                            [TOOL_CALL] search query=test
+                            ---TURN---
+                            [TOOL_CALL] search query=another
+                            ---TURN---
+                            [TOOL_CALL] search query=yet-another""");
+
+            ExecutionContext ctx = buildContext(config, agent);
+
+            NodeResult result = ToolLoopRunner.execute("node1", "test-agent", "Search", agent, ctx);
+
+            assertThat(result.getStatus()).isEqualTo(ResultStatus.FAILURE);
+            assertThat(result.getOutput().toString()).contains("budget exhaustion");
+        }
+    }
+
+    @Nested
+    class UnknownTool {
+
+        @Test
+        void shouldFeedBackUnknownToolAndEventuallySucceed() {
+            when(mockActionExecutor.execute(any(Action.class), any()))
+                    .thenReturn(ActionResult.success("ok", "search output"));
+
+            AgentConfig config = agentConfig(List.of("search"));
+            StubAgent agent = new StubAgent("test-agent", config);
+
+            // First turn: hallucinated tool, second turn: real tool, third: final
+            registerStubResponse(
+                    agent,
+                    """
+                            [TOOL_CALL] nonexistent query=test
+                            ---TURN---
+                            [TOOL_CALL] search query=test
+                            ---TURN---
+                            Got it""");
+
+            ExecutionContext ctx = buildContext(config, agent);
+
+            NodeResult result = ToolLoopRunner.execute("node1", "test-agent", "Search", agent, ctx);
+
+            assertThat(result.getStatus()).isEqualTo(ResultStatus.SUCCESS);
+            // Only the real tool call should have gone to the action executor
+            verify(mockActionExecutor, times(1)).execute(any(Action.Send.class), any());
+        }
+    }
+
+    @Nested
+    class ToolFailure {
+
+        @Test
+        void shouldFeedBackToolFailure() {
+            when(mockActionExecutor.execute(any(Action.class), any()))
+                    .thenReturn(ActionResult.failure("Tool crashed"));
+
+            AgentConfig config = agentConfig(List.of("search"));
+            StubAgent agent = new StubAgent("test-agent", config);
+
+            registerStubResponse(
+                    agent,
+                    """
+                            [TOOL_CALL] search query=test
+                            ---TURN---
+                            Handled the failure gracefully""");
+
+            ExecutionContext ctx = buildContext(config, agent);
+
+            NodeResult result = ToolLoopRunner.execute("node1", "test-agent", "Search", agent, ctx);
+
+            assertThat(result.getStatus()).isEqualTo(ResultStatus.SUCCESS);
+            assertThat(result.getOutput().toString()).isEqualTo("Handled the failure gracefully");
+        }
+    }
+
+    @Nested
+    class EngagementCheck {
+
+        @Test
+        void shouldFailWhenAgentNotToolCapable() {
+            Agent nonToolAgent = mock(Agent.class);
+            when(nonToolAgent.getConfig()).thenReturn(agentConfig(List.of("search")));
+
+            ExecutionContext ctx = buildContext(agentConfig(List.of("search")), nonToolAgent);
+
+            NodeResult result =
+                    ToolLoopRunner.execute("node1", "test-agent", "Prompt", nonToolAgent, ctx);
+
+            assertThat(result.getStatus()).isEqualTo(ResultStatus.FAILURE);
+            assertThat(result.getOutput().toString()).contains("does not implement ToolCapable");
+        }
+
+        @Test
+        void shouldFailWhenToolNotInRegistry() {
+            AgentConfig config = agentConfig(List.of("nonexistent-tool"));
+            StubAgent agent = new StubAgent("test-agent", config);
+
+            registerStubResponse(agent, "Should not reach here");
+
+            ExecutionContext ctx = buildContext(config, agent);
+
+            NodeResult result = ToolLoopRunner.execute("node1", "test-agent", "Prompt", agent, ctx);
+
+            assertThat(result.getStatus()).isEqualTo(ResultStatus.FAILURE);
+            assertThat(result.getOutput().toString()).contains("Unresolvable tools");
+        }
+
+        @Test
+        void shouldFailWhenNoActionExecutorConfigured() {
+            AgentConfig config = agentConfig(List.of("search"));
+            StubAgent agent = new StubAgent("test-agent", config);
+
+            registerStubResponse(agent, "whatever");
+
+            // Build context WITHOUT action executor
+            ExecutionContext ctx =
+                    ExecutionContext.builder()
+                            .state(buildState())
+                            .workflow(buildWorkflow())
+                            .listener(ExecutionListener.NOOP)
+                            .agentRegistry(buildAgentRegistry(config, agent))
+                            .toolRegistry(toolRegistry)
+                            .build();
+
+            NodeResult result = ToolLoopRunner.execute("node1", "test-agent", "Prompt", agent, ctx);
+
+            assertThat(result.getStatus()).isEqualTo(ResultStatus.FAILURE);
+            assertThat(result.getOutput().toString()).contains("no ActionExecutor");
+        }
+    }
+
+    @Nested
+    class RawPayload {
+
+        @Test
+        void shouldSendRawPayloadToActionExecutor() {
+            when(mockActionExecutor.execute(any(Action.class), any()))
+                    .thenReturn(ActionResult.success("ok", "output"));
+
+            AgentConfig config = agentConfig(List.of("search"));
+            StubAgent agent = new StubAgent("test-agent", config);
+
+            registerStubResponse(agent, "[TOOL_CALL] search query={context_var}\n---TURN---\nDone");
+
+            ExecutionContext ctx = buildContext(config, agent);
+
+            ToolLoopRunner.execute("node1", "test-agent", "Search", agent, ctx);
+
+            // Verify the Action.Send was created with rawPayload=true
+            var captor = org.mockito.ArgumentCaptor.forClass(Action.class);
+            verify(mockActionExecutor).execute(captor.capture(), any());
+            Action.Send send = (Action.Send) captor.getValue();
+            assertThat(send.isRawPayload()).isTrue();
+        }
+    }
+
+    // ——— Helpers ———————————————————————————————————————————————————————
+
+    private AgentConfig agentConfig(List<String> tools) {
+        return AgentConfig.builder()
+                .id("test-agent")
+                .role("tester")
+                .model("stub")
+                .tools(tools)
+                .build();
+    }
+
+    private void registerStubResponse(StubAgent agent, String response) {
+        io.hensu.core.agent.stub.StubResponseRegistry.getInstance()
+                .registerResponse("test-agent", response);
+    }
+
+    private ExecutionContext buildContext(AgentConfig config, Agent agent) {
+        return ExecutionContext.builder()
+                .state(buildState())
+                .workflow(buildWorkflow())
+                .listener(ExecutionListener.NOOP)
+                .agentRegistry(buildAgentRegistry(config, agent))
+                .actionExecutor(mockActionExecutor)
+                .toolRegistry(toolRegistry)
+                .build();
+    }
+
+    private AgentRegistry buildAgentRegistry(AgentConfig config, Agent agent) {
+        AgentRegistry registry = mock(AgentRegistry.class);
+        when(registry.getAgent("test-agent")).thenReturn(java.util.Optional.of(agent));
+        return registry;
+    }
+
+    private HensuState buildState() {
+        return new HensuState.Builder()
+                .executionId("test-exec")
+                .workflowId("test-wf")
+                .currentNode("node1")
+                .context(new HashMap<>(Map.of("current_node", "node1")))
+                .history(new ExecutionHistory())
+                .build();
+    }
+
+    private Workflow buildWorkflow() {
+        StandardNode node1 =
+                StandardNode.builder()
+                        .id("node1")
+                        .agentId("test-agent")
+                        .prompt("test")
+                        .transitionRules(List.of(new SuccessTransition("end")))
+                        .build();
+        EndNode end = EndNode.builder().id("end").status(ExitStatus.SUCCESS).build();
+
+        return Workflow.builder()
+                .id("test-wf")
+                .startNode("node1")
+                .nodes(Map.of("node1", node1, "end", end))
+                .build();
+    }
+}

--- a/hensu-core/src/test/java/io/hensu/core/plan/PlanExecutorTest.java
+++ b/hensu-core/src/test/java/io/hensu/core/plan/PlanExecutorTest.java
@@ -50,7 +50,8 @@ class PlanExecutorTest {
                         Instant start = Instant.now();
                         ActionResult result =
                                 mockActionExecutor.execute(
-                                        new Action.Send(action.toolName(), action.arguments()),
+                                        new Action.Send(
+                                                action.toolName(), action.arguments(), false),
                                         context);
                         Duration duration = Duration.between(start, Instant.now());
                         return result.success()

--- a/hensu-dsl/src/main/kotlin/io/hensu/dsl/builders/ActionNodeBuilder.kt
+++ b/hensu-dsl/src/main/kotlin/io/hensu/dsl/builders/ActionNodeBuilder.kt
@@ -59,7 +59,7 @@ class ActionNodeBuilder(private val id: String) : BaseNodeBuilder, TransitionMar
      * @param handlerId identifier of the registered action handler
      */
     fun send(handlerId: String) {
-        actions.add(Action.Send(handlerId))
+        actions.add(Action.Send(handlerId, emptyMap(), false))
     }
 
     /**
@@ -88,7 +88,7 @@ class ActionNodeBuilder(private val id: String) : BaseNodeBuilder, TransitionMar
      * @param payload action-specific data passed to the handler
      */
     fun send(handlerId: String, payload: Map<String, Any>) {
-        actions.add(Action.Send(handlerId, payload))
+        actions.add(Action.Send(handlerId, payload, false))
     }
 
     /**

--- a/hensu-dsl/src/main/kotlin/io/hensu/dsl/builders/AgentBuilder.kt
+++ b/hensu-dsl/src/main/kotlin/io/hensu/dsl/builders/AgentBuilder.kt
@@ -125,6 +125,9 @@ class AgentBuilder(private val id: String) {
     /** Request timeout in seconds, may be null to use default. */
     var timeout: Long? = null
 
+    /** Maximum number of tool calls allowed per execution, may be null to use default (10). */
+    var maxToolCalls: Int? = null
+
     /**
      * Builds the immutable [AgentConfig] from this builder.
      *
@@ -148,6 +151,7 @@ class AgentBuilder(private val id: String) {
             .frequencyPenalty(frequencyPenalty)
             .presencePenalty(presencePenalty)
             .timeout(timeout)
+            .maxToolCalls(maxToolCalls)
             .build()
     }
 }

--- a/hensu-langchain4j-adapter/build.gradle.kts
+++ b/hensu-langchain4j-adapter/build.gradle.kts
@@ -12,4 +12,6 @@ dependencies {
     implementation("dev.langchain4j:langchain4j-anthropic")
     implementation("dev.langchain4j:langchain4j-open-ai")
     implementation("dev.langchain4j:langchain4j-google-ai-gemini")
+
+    implementation("com.fasterxml.jackson.core:jackson-databind")
 }

--- a/hensu-langchain4j-adapter/src/main/java/io/hensu/adapter/langchain4j/LangChain4jAgent.java
+++ b/hensu-langchain4j-adapter/src/main/java/io/hensu/adapter/langchain4j/LangChain4jAgent.java
@@ -9,9 +9,13 @@ import dev.langchain4j.model.chat.response.ChatResponse;
 import io.hensu.core.agent.Agent;
 import io.hensu.core.agent.AgentConfig;
 import io.hensu.core.agent.AgentResponse;
+import io.hensu.core.agent.ToolCapable;
+import io.hensu.core.agent.ToolSession;
+import io.hensu.core.tool.ToolDefinition;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Logger;
 
 /// LangChain4j implementation of {@link Agent}.
@@ -28,7 +32,7 @@ import java.util.logging.Logger;
 ///
 /// @see LangChain4jProvider for agent creation
 /// @see Agent for the contract
-public class LangChain4jAgent implements Agent {
+public class LangChain4jAgent implements Agent, ToolCapable {
 
     private static final Logger logger = Logger.getLogger(LangChain4jAgent.class.getName());
 
@@ -36,6 +40,7 @@ public class LangChain4jAgent implements Agent {
     private final AgentConfig config;
     private final ChatModel model;
     private final List<ChatMessage> conversationHistory;
+    private final ReentrantLock historyLock = new ReentrantLock();
 
     /// Creates a new agent wrapping the given chat model.
     ///
@@ -78,8 +83,13 @@ public class LangChain4jAgent implements Agent {
             logger.fine("Agent '" + id + "' output:\n" + output);
 
             if (config.isMaintainContext()) {
-                conversationHistory.add(UserMessage.from(prompt));
-                conversationHistory.add(aiMessage);
+                historyLock.lock();
+                try {
+                    conversationHistory.add(UserMessage.from(prompt));
+                    conversationHistory.add(aiMessage);
+                } finally {
+                    historyLock.unlock();
+                }
             }
 
             Map<String, Object> metadata = buildMetadata(response, startTime);
@@ -101,6 +111,36 @@ public class LangChain4jAgent implements Agent {
     @Override
     public AgentConfig getConfig() {
         return config;
+    }
+
+    @Override
+    public ToolSession openToolSession(
+            String prompt, Map<String, Object> context, List<ToolDefinition> tools) {
+        return new LangChain4jToolSession(this, model, config, prompt, context, tools);
+    }
+
+    /// Appends the final prompt/answer pair to shared conversation history.
+    ///
+    /// Called by {@link LangChain4jToolSession#close()} under the session's control.
+    void appendToHistory(UserMessage userMessage, AiMessage aiMessage) {
+        if (!config.isMaintainContext()) return;
+        historyLock.lock();
+        try {
+            conversationHistory.add(userMessage);
+            conversationHistory.add(aiMessage);
+        } finally {
+            historyLock.unlock();
+        }
+    }
+
+    /// Returns a snapshot of the current conversation history for session initialization.
+    List<ChatMessage> getHistorySnapshot() {
+        historyLock.lock();
+        try {
+            return new ArrayList<>(conversationHistory);
+        } finally {
+            historyLock.unlock();
+        }
     }
 
     /// Builds the ordered message list: system prompt, history, then user prompt.
@@ -128,8 +168,9 @@ public class LangChain4jAgent implements Agent {
             }
         }
 
-        if (config.isMaintainContext() && !conversationHistory.isEmpty()) {
-            messages.addAll(conversationHistory);
+        if (config.isMaintainContext()) {
+            List<ChatMessage> snapshot = getHistorySnapshot();
+            messages.addAll(snapshot);
         }
 
         messages.add(UserMessage.from(prompt));

--- a/hensu-langchain4j-adapter/src/main/java/io/hensu/adapter/langchain4j/LangChain4jProvider.java
+++ b/hensu-langchain4j-adapter/src/main/java/io/hensu/adapter/langchain4j/LangChain4jProvider.java
@@ -142,7 +142,9 @@ public class LangChain4jProvider implements AgentProvider {
                         .modelName(config.getModel())
                         .temperature(getTemperature(config))
                         .maxOutputTokens(getMaxTokens(config))
-                        .timeout(Duration.ofSeconds(getTimeout(config)));
+                        .timeout(Duration.ofSeconds(getTimeout(config)))
+                        .returnThinking(true)
+                        .sendThinking(true);
 
         if (config.getTopP() != null) builder.topP(config.getTopP());
 

--- a/hensu-langchain4j-adapter/src/main/java/io/hensu/adapter/langchain4j/LangChain4jToolSession.java
+++ b/hensu-langchain4j-adapter/src/main/java/io/hensu/adapter/langchain4j/LangChain4jToolSession.java
@@ -1,0 +1,241 @@
+package io.hensu.adapter.langchain4j;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.request.json.JsonBooleanSchema;
+import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
+import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
+import dev.langchain4j.model.chat.request.json.JsonStringSchema;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import io.hensu.core.agent.AgentConfig;
+import io.hensu.core.agent.AgentResponse;
+import io.hensu.core.agent.ToolSession;
+import io.hensu.core.tool.ToolCallResult;
+import io.hensu.core.tool.ToolDefinition;
+import java.util.*;
+import java.util.logging.Logger;
+
+/// LangChain4j implementation of {@link ToolSession}.
+///
+/// Manages a session-private message list for tool-call rounds. At session close,
+/// appends only the final (prompt, answer) pair to the agent's shared history
+/// under its lock – preventing cross-branch bleed of intermediate tool turns.
+class LangChain4jToolSession implements ToolSession {
+
+    private static final Logger logger = Logger.getLogger(LangChain4jToolSession.class.getName());
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final LangChain4jAgent agent;
+    private final ChatModel model;
+    private final AgentConfig config;
+    private final List<ChatMessage> sessionMessages;
+    private final List<ToolSpecification> toolSpecs;
+    private final Deque<ToolExecutionRequest> pendingQueue = new ArrayDeque<>();
+    private ToolExecutionRequest lastDispatchedRequest;
+    private UserMessage originalUserMessage;
+    private AiMessage lastAiMessage;
+
+    LangChain4jToolSession(
+            LangChain4jAgent agent,
+            ChatModel model,
+            AgentConfig config,
+            String prompt,
+            Map<String, Object> context,
+            List<ToolDefinition> tools) {
+        this.agent = agent;
+        this.model = model;
+        this.config = config;
+        this.sessionMessages = new ArrayList<>();
+        this.toolSpecs = tools.stream().map(LangChain4jToolSession::toToolSpec).toList();
+
+        buildInitialMessages(prompt, context);
+    }
+
+    @Override
+    public AgentResponse start() {
+        ChatRequest request =
+                ChatRequest.builder()
+                        .messages(sessionMessages)
+                        .toolSpecifications(toolSpecs)
+                        .build();
+        ChatResponse chatResponse = model.chat(request);
+        return processResponse(chatResponse);
+    }
+
+    @Override
+    public AgentResponse submit(ToolCallResult result) {
+        // Add the tool execution result for the last dispatched request
+        if (lastDispatchedRequest != null) {
+            sessionMessages.add(
+                    ToolExecutionResultMessage.from(lastDispatchedRequest, result.asText()));
+            lastDispatchedRequest = null;
+        }
+
+        // If more tool calls remain in this round, dispatch the next one
+        if (!pendingQueue.isEmpty()) {
+            ToolExecutionRequest next = pendingQueue.poll();
+            lastDispatchedRequest = next;
+            return toToolRequest(next);
+        }
+
+        // All tool calls from this round answered — re-call the model
+        ChatRequest request =
+                ChatRequest.builder()
+                        .messages(sessionMessages)
+                        .toolSpecifications(toolSpecs)
+                        .build();
+        ChatResponse chatResponse = model.chat(request);
+        return processResponse(chatResponse);
+    }
+
+    @Override
+    public void compact() {
+        if (sessionMessages.size() <= 3) return;
+
+        // Retain: system message (if present), original user message, last AI message
+        List<ChatMessage> compacted = new ArrayList<>();
+        for (ChatMessage msg : sessionMessages) {
+            if (msg instanceof SystemMessage) {
+                compacted.add(msg);
+                break;
+            }
+        }
+        if (originalUserMessage != null) {
+            compacted.add(originalUserMessage);
+        }
+        if (lastAiMessage != null) {
+            compacted.add(lastAiMessage);
+        }
+        sessionMessages.clear();
+        sessionMessages.addAll(compacted);
+        pendingQueue.clear();
+    }
+
+    @Override
+    public void close() {
+        if (lastAiMessage != null && lastAiMessage.text() != null && originalUserMessage != null) {
+            agent.appendToHistory(originalUserMessage, lastAiMessage);
+        }
+    }
+
+    private AgentResponse processResponse(ChatResponse chatResponse) {
+        AiMessage aiMessage = chatResponse.aiMessage();
+        lastAiMessage = aiMessage;
+        sessionMessages.add(aiMessage);
+
+        if (aiMessage.hasToolExecutionRequests()) {
+            List<ToolExecutionRequest> requests = aiMessage.toolExecutionRequests();
+            pendingQueue.clear();
+            pendingQueue.addAll(requests);
+
+            ToolExecutionRequest first = pendingQueue.poll();
+            lastDispatchedRequest = first;
+            return toToolRequest(first);
+        }
+
+        String text = aiMessage.text();
+        if (text == null) text = "";
+        return AgentResponse.TextResponse.of(text);
+    }
+
+    private AgentResponse.ToolRequest toToolRequest(ToolExecutionRequest request) {
+        Map<String, Object> arguments = parseArguments(request.arguments());
+        return AgentResponse.ToolRequest.of(request.name(), arguments);
+    }
+
+    private Map<String, Object> parseArguments(String argumentsJson) {
+        if (argumentsJson == null || argumentsJson.isBlank()) return Map.of();
+        try {
+            return MAPPER.readValue(argumentsJson, new TypeReference<>() {});
+        } catch (Exception e) {
+            logger.warning("Failed to parse tool arguments: " + e.getMessage());
+            return Map.of("_raw", argumentsJson);
+        }
+    }
+
+    private void buildInitialMessages(String prompt, Map<String, Object> context) {
+        String modelName = config.getModel();
+        boolean isGemini = modelName.startsWith("gemini") || modelName.startsWith("gemma");
+
+        if (!config.getRole().isEmpty()) {
+            String systemContent =
+                    buildSystemPrompt(config.getRole(), config.getInstructions(), context);
+            if (isGemini) {
+                prompt = systemContent + prompt;
+            } else {
+                sessionMessages.add(SystemMessage.from(systemContent));
+            }
+        }
+
+        if (config.isMaintainContext()) {
+            sessionMessages.addAll(agent.getHistorySnapshot());
+        }
+
+        originalUserMessage = UserMessage.from(prompt);
+        sessionMessages.add(originalUserMessage);
+    }
+
+    private String buildSystemPrompt(
+            String role, String instructions, Map<String, Object> context) {
+        var sb = new StringBuilder();
+        sb.append("You are a ").append(role).append(".\n\n");
+        if (instructions != null && !instructions.isEmpty()) {
+            sb.append(instructions).append("\n\n");
+        }
+        if (context != null && !context.isEmpty()) {
+            sb.append("Context information:\n");
+            context.forEach(
+                    (key, value) -> {
+                        if (!key.startsWith("_")
+                                && !key.equals("retry_attempt")
+                                && !key.equals("backtrack_reason")
+                                && !key.equals("loop_iteration")) {
+                            sb.append("- ").append(key).append(": ").append(value).append("\n");
+                        }
+                    });
+        }
+        return sb.toString();
+    }
+
+    private static ToolSpecification toToolSpec(ToolDefinition tool) {
+        Map<String, JsonSchemaElement> properties = new LinkedHashMap<>();
+        List<String> required = new ArrayList<>();
+
+        for (var param : tool.parameters()) {
+            properties.put(param.name(), toSchemaElement(param.type()));
+            if (param.required()) {
+                required.add(param.name());
+            }
+        }
+
+        JsonObjectSchema paramSchema =
+                JsonObjectSchema.builder().addProperties(properties).required(required).build();
+
+        return ToolSpecification.builder()
+                .name(tool.name())
+                .description(tool.description())
+                .parameters(paramSchema)
+                .build();
+    }
+
+    private static JsonSchemaElement toSchemaElement(String type) {
+        return switch (type.toLowerCase()) {
+            case "string" -> JsonStringSchema.builder().build();
+            case "number" -> JsonNumberSchema.builder().build();
+            case "integer", "int" -> JsonIntegerSchema.builder().build();
+            case "boolean", "bool" -> JsonBooleanSchema.builder().build();
+            default -> JsonStringSchema.builder().build();
+        };
+    }
+}

--- a/hensu-serialization/src/main/java/io/hensu/serialization/ActionDeserializer.java
+++ b/hensu-serialization/src/main/java/io/hensu/serialization/ActionDeserializer.java
@@ -52,7 +52,8 @@ class ActionDeserializer extends StdDeserializer<Action> {
                         root.has("payload")
                                 ? mapper.convertValue(root.get("payload"), new TypeReference<>() {})
                                 : Map.of();
-                yield new Action.Send(handlerId, payload);
+                boolean rawPayload = root.has("rawPayload") && root.get("rawPayload").asBoolean();
+                yield new Action.Send(handlerId, payload, rawPayload);
             }
             case "execute" -> new Action.Execute(root.get("commandId").asText());
             default -> throw new IOException("Unknown Action type: " + type);

--- a/hensu-serialization/src/main/java/io/hensu/serialization/ActionSerializer.java
+++ b/hensu-serialization/src/main/java/io/hensu/serialization/ActionSerializer.java
@@ -42,6 +42,9 @@ class ActionSerializer extends StdSerializer<Action> {
                 if (!s.getPayload().isEmpty()) {
                     provider.defaultSerializeField("payload", s.getPayload(), gen);
                 }
+                if (s.isRawPayload()) {
+                    gen.writeBooleanField("rawPayload", true);
+                }
             }
             case Action.Execute e -> {
                 gen.writeStringField("type", "execute");

--- a/hensu-serialization/src/test/java/io/hensu/serialization/WorkflowSerializerTest.java
+++ b/hensu-serialization/src/test/java/io/hensu/serialization/WorkflowSerializerTest.java
@@ -115,7 +115,8 @@ class WorkflowSerializerTest {
                         .id("notify")
                         .actions(
                                 List.of(
-                                        new Action.Send("slack", Map.of("channel", "#general")),
+                                        new Action.Send(
+                                                "slack", Map.of("channel", "#general"), false),
                                         new Action.Execute("deploy-script")))
                         .transitionRules(List.of(new SuccessTransition("done")))
                         .build();
@@ -139,6 +140,40 @@ class WorkflowSerializerTest {
 
         Action.Execute exec = (Action.Execute) restoredAction.getActions().get(1);
         assertThat(exec.getCommandId()).isEqualTo("deploy-script");
+    }
+
+    @Test
+    void roundTrip_actionNode_rawPayloadPreserved() {
+        ActionNode actionNode =
+                ActionNode.builder()
+                        .id("notify")
+                        .actions(
+                                List.of(
+                                        new Action.Send("tool", Map.of("arg", "{var}"), true),
+                                        new Action.Send(
+                                                "slack", Map.of("msg", "{greeting}"), false)))
+                        .transitionRules(List.of(new SuccessTransition("done")))
+                        .build();
+        EndNode end = EndNode.builder().id("done").status(ExitStatus.SUCCESS).build();
+
+        Workflow workflow =
+                Workflow.builder()
+                        .id("test")
+                        .startNode("notify")
+                        .nodes(Map.of("notify", actionNode, "done", end))
+                        .build();
+
+        Workflow restored = WorkflowSerializer.fromJson(WorkflowSerializer.toJson(workflow));
+
+        ActionNode restoredAction = (ActionNode) restored.getNodes().get("notify");
+        assertThat(restoredAction.getActions()).hasSize(2);
+
+        Action.Send rawSend = (Action.Send) restoredAction.getActions().getFirst();
+        assertThat(rawSend.isRawPayload()).isTrue();
+        assertThat(rawSend.getPayload()).containsEntry("arg", "{var}");
+
+        Action.Send dslSend = (Action.Send) restoredAction.getActions().get(1);
+        assertThat(dslSend.isRawPayload()).isFalse();
     }
 
     @Test

--- a/hensu-server/README.md
+++ b/hensu-server/README.md
@@ -277,7 +277,7 @@ The server initializes core infrastructure via CDI:
 
 1. `HensuEnvironmentProducer` creates `HensuEnvironment` via `HensuFactory.builder()`
 2. `ServerConfiguration` delegates core components for CDI injection
-3. `ServerActionExecutor` routes `Action.Send` to registered handlers (MCP and others) and rejects `Action.Execute` (local command execution)
+3. `ServerActionExecutor` routes `Action.Send` to registered handlers (MCP and others), skipping template resolution for agent-originated tool calls (`rawPayload`), and rejects `Action.Execute` (local command execution)
 
 See [Server Developer Guide](../docs/developer-guide-server.md) for implementation details.
 

--- a/hensu-server/src/main/java/io/hensu/server/action/ServerActionExecutor.java
+++ b/hensu-server/src/main/java/io/hensu/server/action/ServerActionExecutor.java
@@ -8,7 +8,6 @@ import io.hensu.core.template.TemplateResolver;
 import io.hensu.server.mcp.McpSidecar;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -76,12 +75,16 @@ public class ServerActionExecutor implements ActionExecutor {
             ActionHandler mcpHandler = handlers.get(McpSidecar.HANDLER_ID);
             if (mcpHandler != null) {
                 LOG.debugv("Routing tool '{0}' through MCP handler", handlerId);
+                Map<String, Object> effectivePayload =
+                        send.isRawPayload()
+                                ? send.getPayload()
+                                : templateResolver.resolvePayload(send.getPayload(), context);
                 Map<String, Object> mcpPayload =
                         Map.of(
                                 McpSidecar.TOOL_KEY,
                                 handlerId,
                                 McpSidecar.ARGUMENTS_KEY,
-                                resolvePayload(send.getPayload(), context));
+                                effectivePayload);
                 return mcpHandler.execute(mcpPayload, context);
             }
             LOG.warnv(
@@ -91,21 +94,10 @@ public class ServerActionExecutor implements ActionExecutor {
 
         LOG.debugv("Executing send action via handler: {0}", handlerId);
 
-        Map<String, Object> resolvedPayload = resolvePayload(send.getPayload(), context);
-        return handler.execute(resolvedPayload, context);
-    }
-
-    private Map<String, Object> resolvePayload(
-            Map<String, Object> payload, Map<String, Object> context) {
-        Map<String, Object> resolved = new HashMap<>();
-        for (Map.Entry<String, Object> entry : payload.entrySet()) {
-            Object value = entry.getValue();
-            if (value instanceof String stringValue) {
-                resolved.put(entry.getKey(), templateResolver.resolve(stringValue, context));
-            } else {
-                resolved.put(entry.getKey(), value);
-            }
-        }
-        return resolved;
+        Map<String, Object> effectivePayload =
+                send.isRawPayload()
+                        ? send.getPayload()
+                        : templateResolver.resolvePayload(send.getPayload(), context);
+        return handler.execute(effectivePayload, context);
     }
 }

--- a/hensu-server/src/main/java/io/hensu/server/config/HensuEnvironmentProducer.java
+++ b/hensu-server/src/main/java/io/hensu/server/config/HensuEnvironmentProducer.java
@@ -9,6 +9,7 @@ import io.hensu.core.execution.executor.GenericNodeHandler;
 import io.hensu.core.plan.PlanObserver;
 import io.hensu.core.review.ReviewHandler;
 import io.hensu.serialization.plan.JacksonPlanResponseParser;
+import io.hensu.server.mcp.TenantToolRegistry;
 import io.hensu.server.persistence.ExecutionLeaseManager;
 import io.hensu.server.persistence.JdbcWorkflowRepository;
 import io.hensu.server.persistence.JdbcWorkflowStateRepository;
@@ -70,6 +71,8 @@ public class HensuEnvironmentProducer {
 
     @Inject Instance<PlanObserver> planObservers;
 
+    @Inject TenantToolRegistry tenantToolRegistry;
+
     /// Produces the Hensu runtime environment for CDI injection.
     ///
     /// Configures virtual threads, loads credentials from `hensu.credentials.*`
@@ -88,7 +91,8 @@ public class HensuEnvironmentProducer {
                         .agentProviders(List.of(new LangChain4jProvider()))
                         .actionExecutor(actionExecutor)
                         .planObservers(planObservers.stream().toList())
-                        .planResponseParser(new JacksonPlanResponseParser(objectMapper));
+                        .planResponseParser(new JacksonPlanResponseParser(objectMapper))
+                        .toolRegistry(tenantToolRegistry);
 
         boolean dsActive =
                 config.getOptionalValue("quarkus.datasource.active", Boolean.class).orElse(true);

--- a/hensu-server/src/test/java/io/hensu/server/action/ServerActionExecutorTest.java
+++ b/hensu-server/src/test/java/io/hensu/server/action/ServerActionExecutorTest.java
@@ -35,7 +35,7 @@ class ServerActionExecutorTest {
 
             executor.registerHandler(handler);
 
-            Action.Send send = new Action.Send("slack", Map.of("message", "hello"));
+            Action.Send send = new Action.Send("slack", Map.of("message", "hello"), false);
             ActionResult result = executor.execute(send, Map.of());
 
             assertThat(result.success()).isTrue();
@@ -45,7 +45,7 @@ class ServerActionExecutorTest {
 
         @Test
         void shouldReturnFailureWhenHandlerNotFound() {
-            Action.Send send = new Action.Send("unknown");
+            Action.Send send = new Action.Send("unknown", Map.of(), false);
             ActionResult result = executor.execute(send, Map.of());
 
             assertThat(result.success()).isFalse();
@@ -60,7 +60,7 @@ class ServerActionExecutorTest {
 
             executor.registerHandler(handler);
 
-            Action.Send send = new Action.Send("notify", Map.of("msg", "{greeting}"));
+            Action.Send send = new Action.Send("notify", Map.of("msg", "{greeting}"), false);
             executor.execute(send, Map.of("greeting", "hello world"));
 
             verify(handler).execute(eq(Map.of("msg", "hello world")), any());
@@ -74,10 +74,44 @@ class ServerActionExecutorTest {
 
             executor.registerHandler(handler);
 
-            Action.Send send = new Action.Send("notify", Map.of("count", 42));
+            Action.Send send = new Action.Send("notify", Map.of("count", 42), false);
             executor.execute(send, Map.of());
 
             verify(handler).execute(eq(Map.of("count", 42)), any());
+        }
+    }
+
+    @Nested
+    class RawPayload {
+
+        @Test
+        void shouldNotResolveTemplatesWhenRawPayloadTrue() {
+            ActionHandler handler = mock(ActionHandler.class);
+            when(handler.getHandlerId()).thenReturn("notify");
+            when(handler.execute(any(), any())).thenReturn(ActionResult.success("ok"));
+
+            executor.registerHandler(handler);
+
+            // Agent-originated payload with template-like content
+            Action.Send send = new Action.Send("notify", Map.of("msg", "{greeting}"), true);
+            executor.execute(send, Map.of("greeting", "hello world"));
+
+            // Raw payload should NOT be resolved — {greeting} should pass through verbatim
+            verify(handler).execute(eq(Map.of("msg", "{greeting}")), any());
+        }
+
+        @Test
+        void shouldResolveTemplatesWhenRawPayloadFalse() {
+            ActionHandler handler = mock(ActionHandler.class);
+            when(handler.getHandlerId()).thenReturn("notify");
+            when(handler.execute(any(), any())).thenReturn(ActionResult.success("ok"));
+
+            executor.registerHandler(handler);
+
+            Action.Send send = new Action.Send("notify", Map.of("msg", "{greeting}"), false);
+            executor.execute(send, Map.of("greeting", "hello world"));
+
+            verify(handler).execute(eq(Map.of("msg", "hello world")), any());
         }
     }
 

--- a/hensu-server/src/test/java/io/hensu/server/integration/ToolLoopIntegrationTest.java
+++ b/hensu-server/src/test/java/io/hensu/server/integration/ToolLoopIntegrationTest.java
@@ -1,0 +1,90 @@
+package io.hensu.server.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.hensu.core.execution.action.ActionExecutor;
+import io.hensu.core.state.HensuSnapshot;
+import io.hensu.core.tool.ToolDefinition;
+import io.hensu.server.mcp.TenantToolRegistry;
+import io.hensu.server.workflow.ExecutionStartResult;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/// Integration tests for the agent-native tool loop.
+///
+/// Verifies end-to-end tool execution through the full Quarkus stack:
+/// stub agent → ToolLoopRunner → ActionExecutor → TestActionHandler → stub feed-back
+///  → final answer.
+@QuarkusTest
+@TestProfile(InMemoryTestProfile.class)
+class ToolLoopIntegrationTest extends IntegrationTestBase {
+
+    @Inject TenantToolRegistry toolRegistry;
+    @Inject TestActionHandler testActionHandler;
+    @Inject ActionExecutor actionExecutor;
+
+    @BeforeEach
+    void setUpTools() {
+        testActionHandler.reset();
+        actionExecutor.registerHandler(testActionHandler);
+        toolRegistry.register(
+                ToolDefinition.of(
+                        "test-tool",
+                        "Test tool for integration tests",
+                        List.of(
+                                ToolDefinition.ParameterDef.required(
+                                        "input", "string", "Input parameter"))));
+    }
+
+    @Test
+    void shouldExecuteToolLoopEndToEnd() {
+        var workflow = loadWorkflow("tool-loop.json");
+
+        // Stub: first turn requests tool, second turn returns final text
+        registerStub(
+                "tool-agent",
+                "[TOOL_CALL] test-tool input=hello\n---TURN---\nFinal answer from tool results");
+
+        Map<String, Object> context = new HashMap<>();
+        context.put("query", "test topic");
+        ExecutionStartResult result = pushAndExecute(workflow, context);
+
+        // Verify execution completed
+        Optional<HensuSnapshot> snapshot =
+                workflowStateRepository.findByExecutionId(TEST_TENANT, result.executionId());
+        assertThat(snapshot).isPresent();
+        assertThat(snapshot.get().checkpointReason()).isEqualTo("completed");
+
+        // Verify the tool handler received the call
+        assertThat(testActionHandler.getReceivedPayloads()).hasSize(1);
+        assertThat(testActionHandler.getReceivedPayloads().getFirst())
+                .containsEntry("input", "hello");
+    }
+
+    @Test
+    void shouldHandleToolLoopWithoutToolCalls() {
+        var workflow = loadWorkflow("tool-loop.json");
+
+        // Stub: agent responds immediately without tool calls
+        registerStub("tool-agent", "Direct answer, no tools needed");
+
+        Map<String, Object> context = new HashMap<>();
+        context.put("query", "simple question");
+        ExecutionStartResult result = pushAndExecute(workflow, context);
+
+        Optional<HensuSnapshot> snapshot =
+                workflowStateRepository.findByExecutionId(TEST_TENANT, result.executionId());
+        assertThat(snapshot).isPresent();
+        assertThat(snapshot.get().checkpointReason()).isEqualTo("completed");
+
+        // No tool calls should have been made
+        assertThat(testActionHandler.getReceivedPayloads()).isEmpty();
+    }
+}

--- a/hensu-server/src/test/resources/workflows/tool-loop.json
+++ b/hensu-server/src/test/resources/workflows/tool-loop.json
@@ -1,0 +1,38 @@
+{
+  "id" : "tool-loop",
+  "version" : "1.0.0",
+  "stateSchema" : {
+    "variables" : [ {
+      "name" : "query",
+      "type" : "STRING",
+      "isInput" : true
+    } ]
+  },
+  "startNode" : "search-node",
+  "agents" : {
+    "tool-agent" : {
+      "id" : "tool-agent",
+      "role" : "researcher",
+      "model" : "stub",
+      "temperature" : 0.7,
+      "tools" : [ "test-tool" ]
+    }
+  },
+  "nodes" : {
+    "search-node" : {
+      "id" : "search-node",
+      "nodeType" : "STANDARD",
+      "agentId" : "tool-agent",
+      "prompt" : "Research {query} using available tools",
+      "transitionRules" : [ {
+        "type" : "success",
+        "targetNode" : "done"
+      } ]
+    },
+    "done" : {
+      "id" : "done",
+      "nodeType" : "END",
+      "status" : "SUCCESS"
+    }
+  }
+}

--- a/integrations/spring-reference-client/src/main/java/io/hensu/integrations/springclient/mcp/HensuMcpTransport.java
+++ b/integrations/spring-reference-client/src/main/java/io/hensu/integrations/springclient/mcp/HensuMcpTransport.java
@@ -156,7 +156,13 @@ public class HensuMcpTransport {
 
         LOG.info("MCP tool call received: tool={}, requestId={}", toolName, requestId);
 
-        Map<String, Object> result = dispatcher.dispatch(toolName, arguments);
+        Map<String, Object> result;
+        try {
+            result = dispatcher.dispatch(toolName, arguments);
+        } catch (Exception e) {
+            LOG.error("Tool execution failed for '{}': {}", toolName, e.getMessage());
+            result = Map.of("error", "Execution error: " + e.getMessage());
+        }
         postResponse(requestId, result);
     }
 

--- a/integrations/spring-reference-client/working-dir/workflows/risk-assessment.kt
+++ b/integrations/spring-reference-client/working-dir/workflows/risk-assessment.kt
@@ -48,6 +48,7 @@ fun riskAssessmentWorkflow() = workflow("risk-assessment") {
             role = "Senior credit risk analyst specialising in SMB lending decisions"
             model = Models.GEMINI_3_1_FLASH_LITE
             temperature = 0.2
+            tools = listOf("fetch_customer_data", "calculate_risk_score")
         }
     }
 
@@ -63,17 +64,10 @@ fun riskAssessmentWorkflow() = workflow("risk-assessment") {
                 Customer ID : {customerId}
                 Request type: {requestType}
 
-                Use the available tools in this order:
-                1. Call fetch_customer_data to retrieve the customer's full financial profile.
-                2. Call calculate_risk_score to compute the composite risk score and breakdown.
-                3. Synthesise a recommendation using both the raw data and the risk assessment.
+                Retrieve the customer's financial profile, compute their risk score,
+                and synthesise a recommendation covering positive factors, risk factors,
+                any conditions, and a summary paragraph for the credit committee.
             """.trimIndent()
-
-            planning {
-                mode = PlanningMode.DYNAMIC
-                maxSteps = 5
-                maxDuration = Duration.ofMinutes(3)
-            }
 
             review {
                 mode = ReviewMode.REQUIRED


### PR DESCRIPTION
The plan subsystem's ToolCallStepHandler is the only way agents can execute tools today, coupling tool use to the planning role. This introduces a direct ToolCapable/ToolSession protocol so any agent can request tools natively – a prerequisite for removing the plan subsystem entirely.

Agents that declare tools now enter a bounded loop driven by ToolLoopRunner: the sealed AgentResponse hierarchy (TextResponse, ToolRequest, Error) controls flow with no explicit "done" signal. Budget exhaustion gives the agent one final call to summarize before hard failure. Action.Send gains a rawPayload flag to prevent template-exfiltration of LLM-generated tool arguments.

#88 PR 4/5

Signed-off-by: Aleksandr Suvorov <asuvorov@hensu.io>