### PR TITLE
fix(cli): show sub-workflow validation summary

### DIFF
--- a/hensu-cli/src/main/java/io/hensu/cli/commands/WorkflowValidateCommand.java
+++ b/hensu-cli/src/main/java/io/hensu/cli/commands/WorkflowValidateCommand.java
@@ -47,6 +47,12 @@ class WorkflowValidateCommand extends WorkflowCommand {
             System.out.println("   Nodes: " + workflow.getNodes().size());
             System.out.println("   Agents: " + workflow.getAgents().size());
 
+            for (Workflow subWorkflow : loadedSubWorkflows) {
+                System.out.println("   Sub-workflow: " + subWorkflow.getMetadata().getName());
+                System.out.println("   Nodes: " + subWorkflow.getNodes().size());
+                System.out.println("   Agents: " + subWorkflow.getAgents().size());
+            }
+
             List<String> unreachable = findUnreachableNodes(workflow);
             if (!unreachable.isEmpty()) {
                 System.out.println(" [WARN] Unreachable nodes: " + String.join(", ", unreachable));

--- a/hensu-cli/src/test/java/io/hensu/cli/commands/WorkflowValidateCommandTest.java
+++ b/hensu-cli/src/test/java/io/hensu/cli/commands/WorkflowValidateCommandTest.java
@@ -10,6 +10,7 @@ import io.hensu.dsl.WorkingDirectory;
 import io.hensu.dsl.parsers.KotlinScriptParser;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,6 +60,33 @@ class WorkflowValidateCommandTest extends BaseWorkflowCommandTest {
         assertThat(output).contains("Name: valid-workflow");
         assertThat(output).contains("Nodes: 2");
         assertThat(output).contains("Agents: 1");
+    }
+
+    @Test
+    void shouldIncludeSubWorkflowSummary() throws Exception {
+        // Given
+        String workflowName = "root-workflow";
+        String subWorkflowName = "child-workflow";
+
+        injectField(command, "workflowName", workflowName);
+        injectField(command, "withNames", List.of(subWorkflowName));
+
+        Workflow rootWorkflow = createTestWorkflow(workflowName, 1, 2);
+        Workflow childWorkflow = createTestWorkflow(subWorkflowName, 2, 3);
+
+        when(kotlinParser.parse(any(WorkingDirectory.class), eq(workflowName)))
+                .thenReturn(rootWorkflow);
+        when(kotlinParser.parse(any(WorkingDirectory.class), eq(subWorkflowName)))
+                .thenReturn(childWorkflow);
+
+        // When
+        command.run();
+
+        // Then
+        String output = outContent.toString();
+        assertThat(output).contains("Sub-workflow: child-workflow");
+        assertThat(output).contains("Nodes: 3");
+        assertThat(output).contains("Agents: 2");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- show composed sub-workflows in CLI validation summary
- include each sub-workflow's node and agent counts
- add regression coverage for sub-workflow summary output

## Testing

- `.\gradlew.bat :hensu-cli:test --tests "io.hensu.cli.commands.WorkflowValidateCommandTest"` ✅
- `.\gradlew.bat :hensu-cli:test` has 7 unrelated `CLIActionExecutorTest` failures on Windows because `/bin/sh` is unavailable

Closes #68